### PR TITLE
Add GRATE_MEMORY_FLAG constant to grate-rs

### DIFF
--- a/examples/chroot-grate-rs/src/main.rs
+++ b/examples/chroot-grate-rs/src/main.rs
@@ -1,6 +1,7 @@
 //! `chroot-grate-rs`
 
 use grate_rs::constants::fs::S_IFDIR;
+use grate_rs::constants::lind::GRATE_MEMORY_FLAG;
 use grate_rs::constants::{
     SYS_ACCEPT, SYS_ACCESS, SYS_BIND, SYS_CHDIR, SYS_CHMOD, SYS_CHROOT, SYS_CLONE, SYS_CONNECT,
     SYS_EXECVE, SYS_FCHDIR, SYS_GETCWD, SYS_GETPEERNAME, SYS_GETSOCKNAME, SYS_LINK, SYS_MKDIR,
@@ -73,7 +74,7 @@ fn call_with_rewrites(
             return -(libc::EINVAL as i32);
         }
         args[*idx] = *cstr;
-        arg_cages[*idx] = thiscage | (1u64 << 63);
+        arg_cages[*idx] = thiscage | GRATE_MEMORY_FLAG;
     }
 
     match make_threei_call(
@@ -218,9 +219,9 @@ extern "C" fn readlink_handler(
         cageid,
         path_cage,
         c_path.as_ptr() as u64,
-        thiscage | (1u64 << 63),
+        thiscage | GRATE_MEMORY_FLAG,
         result_buf.as_mut_ptr() as u64,
-        thiscage | (1u64 << 63),
+        thiscage | GRATE_MEMORY_FLAG,
         bufsiz,
         thiscage,
         0,
@@ -302,7 +303,7 @@ extern "C" fn readlinkat_handler(
         if use_chrooted { AT_FDCWD as u64 } else { dirfd },
         dirfd_cage,
         c_path.as_ptr() as u64,
-        thiscage | (1u64 << 63),
+        thiscage | GRATE_MEMORY_FLAG,
         result_buf.as_mut_ptr() as u64,
         thiscage,
         bufsiz,
@@ -417,7 +418,7 @@ extern "C" fn execve_handler(
         thiscage,
         arg1cage,
         rewritten_ptr,
-        thiscage | (1u64 << 63),
+        thiscage | GRATE_MEMORY_FLAG,
         arg2,
         arg2cage,
         arg3,

--- a/lib/grate-rs/src/constants/mod.rs
+++ b/lib/grate-rs/src/constants/mod.rs
@@ -8,6 +8,13 @@ pub mod process;
 
 pub mod lind {
     pub const ELINDAPIABORTED: u64 = 0xE001_0001;
+
+    /// Flag to mark an argcageid as pointing into the grate's own linear memory
+    /// rather than the calling cage's memory. OR this with the cageid when passing
+    /// a pointer that lives in the grate's address space.
+    ///
+    /// Example: `arg2cage = my_cageid | GRATE_MEMORY_FLAG`
+    pub const GRATE_MEMORY_FLAG: u64 = 1u64 << 63;
 }
 
 pub mod syscall_numbers;


### PR DESCRIPTION
Define GRATE_MEMORY_FLAG (1u64 << 63) in grate_rs::constants::lind, matching the C-side GRATE_MEMORY_FLAG from lind_syscall.h. Update chroot-grate-rs to use it instead of the raw literal.