### PR TITLE
strace-rs, mmap: use returned negative values from make_threei_call for strace

### DIFF
--- a/examples/strace-grate-rs/src/strace.rs
+++ b/examples/strace-grate-rs/src/strace.rs
@@ -95,6 +95,7 @@ macro_rules! define_syscall_handler {
                 0
             ) {
                 Ok(val) => val,
+                Err(GrateError::MakeSyscallError(ret)) => ret,
                 Err(_) => -1
             };
 


### PR DESCRIPTION
Fixes https://github.com/Lind-Project/lind-wasm/issues/924