### PR TITLE
Add is_thread_clone to grate-rs

### DIFF
--- a/examples/devnull-grate-rs/src/handlers.rs
+++ b/examples/devnull-grate-rs/src/handlers.rs
@@ -10,7 +10,7 @@ use grate_rs::{
         SYS_CLONE, SYS_CLOSE, SYS_DUP, SYS_DUP2, SYS_EXECVE, SYS_OPEN,
         SYS_READ, SYS_WRITE,
     },
-    copy_data_between_cages, getcageid, make_threei_call,
+    copy_data_between_cages, getcageid, is_thread_clone, make_threei_call,
 };
 
 const MAX_PATH: usize = 256;
@@ -172,7 +172,7 @@ pub extern "C" fn fork_handler(
         Err(_) => return -1,
     };
 
-    if ret > 0 {
+    if ret > 0 && !is_thread_clone(arg1, arg1cage) {
         let _ = fdtables::copy_fdtable_for_cage(cage_id, ret as u64);
     }
     ret

--- a/examples/imfs-grate-rs/src/handlers.rs
+++ b/examples/imfs-grate-rs/src/handlers.rs
@@ -6,7 +6,7 @@
 //! copy data to/from the cage similarly.
 
 use grate_rs::constants::*;
-use grate_rs::{copy_data_between_cages, getcageid, make_threei_call};
+use grate_rs::{copy_data_between_cages, getcageid, is_thread_clone, make_threei_call};
 
 use crate::imfs;
 
@@ -495,12 +495,14 @@ pub extern "C" fn fork_handler(
 
     let child_cage_id = ret as u64;
 
-    // Clone the fdtables for the child — inherits all open fds.
-    let _ = fdtables::copy_fdtable_for_cage(arg1cage, child_cage_id);
+    if !is_thread_clone(arg1, arg1cage) {
+        // Clone the fdtables for the child — inherits all open fds.
+        let _ = fdtables::copy_fdtable_for_cage(arg1cage, child_cage_id);
 
-    imfs::with_imfs(|state| {
-        state.fork(arg1cage, child_cage_id);
-    });
+        imfs::with_imfs(|state| {
+            state.fork(arg1cage, child_cage_id);
+        });
+    }
 
     child_cage_id as i32
 }

--- a/examples/namespace-grate-rs/src/handlers/clamped_lifecycle.rs
+++ b/examples/namespace-grate-rs/src/handlers/clamped_lifecycle.rs
@@ -1,7 +1,7 @@
 use grate_rs::{
     SyscallHandler,
     constants::{SYS_CLONE, SYS_EXEC, SYS_EXIT, SYS_REGISTER_HANDLER},
-    copy_data_between_cages, register_handler,
+    copy_data_between_cages, is_thread_clone, register_handler,
 };
 
 use fdtables;
@@ -223,14 +223,16 @@ pub extern "C" fn fork_handler(
     // Forward the fork to the runtime. Returns child cage ID to parent, 0 to child.
     let child_cage_id = helpers::do_syscall(arg1cage, SYS_CLONE, &args, &arg_cages) as u64;
 
-    // If the forking cage is inside the clamp, the child inherits that status.
-    if helpers::is_cage_clamped(arg1cage) {
-        // Copy the fd table so the child knows which fds are clamped.
-        let _ = fdtables::copy_fdtable_for_cage(arg1cage, child_cage_id);
-    }
+    if !is_thread_clone(arg1, arg1cage) {
+        // If the forking cage is inside the clamp, the child inherits that status.
+        if helpers::is_cage_clamped(arg1cage) {
+            // Copy the fd table so the child knows which fds are clamped.
+            let _ = fdtables::copy_fdtable_for_cage(arg1cage, child_cage_id);
+        }
 
-    // Register our lifecycle handlers on the child so we can track it.
-    register_lifecycle_handlers(child_cage_id);
+        // Register our lifecycle handlers on the child so we can track it.
+        register_lifecycle_handlers(child_cage_id);
+    }
 
     child_cage_id as i32
 }

--- a/examples/write_filter-grate-rs/src/handlers.rs
+++ b/examples/write_filter-grate-rs/src/handlers.rs
@@ -3,7 +3,7 @@ use grate_rs::{
         SYS_CLONE, SYS_DUP, SYS_DUP2, SYS_EXECVE, SYS_OPEN, SYS_PWRITE, SYS_WRITE, SYS_WRITEV, SYS_CLOSE,
         error::EPERM,
     },
-    copy_data_between_cages, getcageid, make_threei_call,
+    copy_data_between_cages, getcageid, is_thread_clone, make_threei_call,
 };
 use std::path::Path;
 
@@ -270,7 +270,9 @@ pub extern "C" fn fork_handler(
     }
 
     let child_cageid = ret as u64;
-    let _ = fdtables::copy_fdtable_for_cage(cage_id, child_cageid as u64);
+    if !is_thread_clone(arg1, arg1cage) {
+        let _ = fdtables::copy_fdtable_for_cage(cage_id, child_cageid);
+    }
 
     child_cageid as i32
 }

--- a/lib/grate-rs/src/lib.rs
+++ b/lib/grate-rs/src/lib.rs
@@ -242,6 +242,26 @@ pub fn getcageid() -> u64 {
     unsafe { getpid_impl() as u64 }
 }
 
+/// Check whether a SYS_CLONE call is a thread creation (not a process fork).
+///
+/// In Lind, `arg1` of SYS_CLONE is a pointer to `struct clone_args` in the
+/// calling cage's memory. The `flags` field is the first u64 in the struct.
+/// If `CLONE_VM` (0x100) is set, it's a thread; otherwise it's a process fork.
+///
+/// Grates should only copy fdtables on process forks, not thread clones
+/// (threads share the parent's fd table).
+pub fn is_thread_clone(clone_args_ptr: u64, clone_args_cage: u64) -> bool {
+    let grate_cage = getcageid();
+    let mut flags: u64 = 0;
+    let _ = copy_data_between_cages(
+        grate_cage, clone_args_cage,
+        clone_args_ptr, clone_args_cage,
+        &mut flags as *mut u64 as u64, grate_cage,
+        8, 0,
+    );
+    (flags & constants::process::CLONE_VM) != 0
+}
+
 /// Dispatch function required by 3i to invoke registered syscall handlers.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn pass_fptr_to_wt(


### PR DESCRIPTION
fix all grates to skip fdtable copy on threads

In Lind, SYS_CLONE arg1 is a pointer to clone_args, not the flags directly. Add grate_rs::is_thread_clone() that reads the flags via copy_data_between_cages and checks CLONE_VM.

Update all grates with fork handlers to only copy fdtables on process forks, not thread clones. Threads share the parent's fd table and should not get a copy.

Affected: devnull, write-filter, imfs, namespace (fs)