### PR TITLE
Mtls demo

### DIFF
--- a/demos/mtls-propagation/README.md
+++ b/demos/mtls-propagation/README.md
@@ -1,0 +1,32 @@
+# mTLS Propagation Demo
+
+Demonstrates that mTLS enforcement propagates automatically to all
+dynamically spawned worker cages via handler table inheritance.
+
+The mtls-grate intercepts `connect()` and `accept()` at the syscall
+boundary and wraps the underlying fd in a TLS session. Because handler
+tables are inherited across `fork`, every worker cage gets mTLS without
+any per-worker configuration. No worker can bypass it.
+
+## What it tests
+
+1. **Depth 0**: Main process accepts a connection, exchanges data through mTLS
+2. **Depth 1**: Forked worker accepts its own connection — mTLS inherited
+3. **Depth 2**: Worker spawns another worker — mTLS still active
+
+Each depth runs an independent server+client test on a different port.
+The cage code does plain TCP — the grate handles all TLS transparently.
+
+## Running
+
+```bash
+bash demos/mtls-propagation/build.sh
+bash demos/mtls-propagation/run.sh
+```
+
+## Why existing tools can't do this
+
+`LD_PRELOAD` cannot replicate this: statically linked binaries and child
+processes that clear `LD_PRELOAD` before `exec` bypass the shim entirely.
+Grate handler tables are inherited at the cage level, not through the
+environment, so they cannot be cleared or bypassed.

--- a/demos/mtls-propagation/build.sh
+++ b/demos/mtls-propagation/build.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# Build everything needed for the mTLS propagation demo.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+LINDFS="${LINDFS:-${LIND_WASM_ROOT:-$HOME/lind-wasm}/lindfs}"
+
+echo "=== Building mTLS Propagation Demo ==="
+
+echo "Building mtls-grate (--release)..."
+(cd "$REPO_ROOT/rust-grates/mtls-grate" && cargo lind_compile --release --output-dir grates)
+
+echo "Compiling test..."
+lind-clang -s "$SCRIPT_DIR/mtls_propagation_test.c"
+
+# Generate test certs if they don't exist
+if [[ ! -f "$LINDFS/certs/cert.pem" ]]; then
+    echo "Generating test certificates..."
+    bash "$REPO_ROOT/rust-grates/mtls-grate/test/setup.sh"
+fi
+
+echo "Done."

--- a/demos/mtls-propagation/mtls_propagation_test.c
+++ b/demos/mtls-propagation/mtls_propagation_test.c
@@ -1,0 +1,171 @@
+/*
+ * mTLS propagation demo.
+ *
+ * Simulates an application that spawns worker cages via fork, where each
+ * worker accepts a connection. The mtls-grate transparently wraps all
+ * connections in TLS without any per-worker configuration.
+ *
+ * Verifies:
+ * 1. Parent (main process) can accept and exchange data through mTLS
+ * 2. Forked worker cages inherit the mTLS handler and can also accept
+ *    and exchange data — no per-worker TLS setup needed
+ * 3. Multiple spawn depths all get mTLS automatically
+ *
+ * Usage:
+ *   lind-wasm grates/mtls-grate.cwasm \
+ *     --cert ./certs/cert.pem --key ./certs/key.pem --ca ./certs/ca.crt \
+ *     -- mtls_propagation_test.cwasm
+ */
+#include <arpa/inet.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#define BASE_PORT 4440
+#define BUF_SIZE 256
+
+static int tests_run = 0;
+static int tests_passed = 0;
+
+#define CHECK(name, expr) do { \
+    tests_run++; \
+    if (expr) { printf("  PASS: %s\n", name); tests_passed++; } \
+    else { printf("  FAIL: %s (errno=%d %s)\n", name, errno, strerror(errno)); } \
+} while (0)
+
+static struct sockaddr_in make_addr(int port) {
+    struct sockaddr_in a;
+    memset(&a, 0, sizeof(a));
+    a.sin_family = AF_INET;
+    a.sin_port = htons(port);
+    a.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    return a;
+}
+
+/*
+ * Run a server+client test at a given port and depth.
+ * Forks: child connects, parent accepts. Both exchange data.
+ * The mTLS grate wraps connect/accept transparently.
+ */
+static void test_at_depth(int depth, int port) {
+    char label[128];
+
+    printf("\n[depth %d, port %d]\n", depth, port);
+
+    int server = socket(AF_INET, SOCK_STREAM, 0);
+    snprintf(label, sizeof(label), "depth %d: socket()", depth);
+    CHECK(label, server >= 0);
+    if (server < 0) return;
+
+    int opt = 1;
+    setsockopt(server, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+
+    struct sockaddr_in addr = make_addr(port);
+    addr.sin_addr.s_addr = htonl(INADDR_ANY);
+
+    snprintf(label, sizeof(label), "depth %d: bind()", depth);
+    CHECK(label, bind(server, (struct sockaddr *)&addr, sizeof(addr)) == 0);
+
+    snprintf(label, sizeof(label), "depth %d: listen()", depth);
+    CHECK(label, listen(server, 1) == 0);
+
+    pid_t pid = fork();
+    if (pid == 0) {
+        /* Child: client — connect and send data */
+        close(server);
+
+        int client = socket(AF_INET, SOCK_STREAM, 0);
+        struct sockaddr_in caddr = make_addr(port);
+        if (connect(client, (struct sockaddr *)&caddr, sizeof(caddr)) < 0) {
+            _exit(1);
+        }
+
+        /* Send a message identifying the depth */
+        char msg[64];
+        int len = snprintf(msg, sizeof(msg), "hello from depth %d client", depth);
+        if (write(client, msg, len) != len) _exit(1);
+
+        /* Read response */
+        char buf[BUF_SIZE] = {0};
+        ssize_t n = read(client, buf, sizeof(buf) - 1);
+        if (n <= 0) _exit(1);
+
+        close(client);
+        _exit(0);
+    }
+
+    /* Parent: server — accept and exchange data */
+    int conn = accept(server, NULL, NULL);
+    snprintf(label, sizeof(label), "depth %d: accept()", depth);
+    CHECK(label, conn >= 0);
+
+    if (conn >= 0) {
+        char buf[BUF_SIZE] = {0};
+        ssize_t n = read(conn, buf, sizeof(buf) - 1);
+        snprintf(label, sizeof(label), "depth %d: read client message", depth);
+        CHECK(label, n > 0);
+
+        char expected[64];
+        snprintf(expected, sizeof(expected), "hello from depth %d client", depth);
+        snprintf(label, sizeof(label), "depth %d: message content correct", depth);
+        CHECK(label, n > 0 && strstr(buf, expected) != NULL);
+
+        /* Send response */
+        char resp[64];
+        int rlen = snprintf(resp, sizeof(resp), "ack from depth %d server", depth);
+        write(conn, resp, rlen);
+
+        close(conn);
+    }
+
+    int status;
+    waitpid(pid, &status, 0);
+    snprintf(label, sizeof(label), "depth %d: client exited cleanly", depth);
+    CHECK(label, WIFEXITED(status) && WEXITSTATUS(status) == 0);
+
+    close(server);
+}
+
+int main(void) {
+    printf("=== mTLS Propagation Demo ===\n");
+    printf("Verifying TLS handler propagation across forked workers.\n");
+
+    /* Depth 0: main process acts as server */
+    test_at_depth(0, BASE_PORT);
+
+    /* Depth 1: forked worker acts as server */
+    pid_t w1 = fork();
+    if (w1 == 0) {
+        test_at_depth(1, BASE_PORT + 1);
+        _exit(0);
+    }
+    if (w1 > 0) {
+        int status;
+        waitpid(w1, &status, 0);
+    }
+
+    /* Depth 2: worker spawns another worker */
+    pid_t w2 = fork();
+    if (w2 == 0) {
+        pid_t w3 = fork();
+        if (w3 == 0) {
+            test_at_depth(2, BASE_PORT + 2);
+            _exit(0);
+        }
+        if (w3 > 0) {
+            int status;
+            waitpid(w3, &status, 0);
+        }
+        _exit(0);
+    }
+    if (w2 > 0) {
+        int status;
+        waitpid(w2, &status, 0);
+    }
+
+    printf("\n=== Result: %d/%d passed ===\n", tests_passed, tests_run);
+    return (tests_passed == tests_run) ? 0 : 1;
+}

--- a/demos/mtls-propagation/run.sh
+++ b/demos/mtls-propagation/run.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# Run the mTLS propagation demo.
+# Run build.sh first.
+
+set -euo pipefail
+
+echo "=== mTLS Propagation Demo ==="
+echo ""
+echo "The mtls-grate transparently wraps all TCP connections in TLS."
+echo "Handler tables propagate across fork, so all worker cages get"
+echo "mTLS automatically — no per-worker configuration needed."
+echo ""
+
+lind-wasm grates/mtls-grate.cwasm \
+  --cert ./certs/cert.pem \
+  --key ./certs/key.pem \
+  --ca ./certs/ca.crt \
+  -- mtls_propagation_test.cwasm

--- a/demos/mtls-propagation/run.sh
+++ b/demos/mtls-propagation/run.sh
@@ -13,7 +13,7 @@ echo "mTLS automatically — no per-worker configuration needed."
 echo ""
 
 lind-wasm grates/mtls-grate.cwasm \
-  --server-cert ./certs/cert.pem \
-  --server-key ./certs/key.pem \
+  --server-cert ./certs/server.crt \
+  --server-key ./certs/server.key \
   --ca ./certs/ca.crt \
   -- mtls_propagation_test.cwasm

--- a/demos/mtls-propagation/run.sh
+++ b/demos/mtls-propagation/run.sh
@@ -13,7 +13,7 @@ echo "mTLS automatically — no per-worker configuration needed."
 echo ""
 
 lind-wasm grates/mtls-grate.cwasm \
-  --cert ./certs/cert.pem \
-  --key ./certs/key.pem \
+  --server-cert ./certs/cert.pem \
+  --server-key ./certs/key.pem \
   --ca ./certs/ca.crt \
   -- mtls_propagation_test.cwasm


### PR DESCRIPTION
  ## Summary                                                                                                                                                                           
                                                                                                                                                                                       
  Demonstrates that mTLS enforcement propagates automatically to dynamically                                                                                                           
  spawned worker cages via handler table inheritance. The mtls-grate wraps                                                                                                             
  all TCP connections in TLS at the syscall boundary — no per-worker                                                                                                                   
  configuration needed, and no worker can bypass it.                                                                                                                                   
                                                                                                                                                                                       
  ## What it tests                                                                                                                                                                     
                                                                                                                                                                                       
  A simulated application spawns workers via fork at multiple depths.                                                                                                                  
  Each worker independently accepts a connection and exchanges data.                                                                                                                   
  The cage code does plain TCP — the grate handles TLS transparently.                                                                                                                  
                                                                                                                                                                                       
  - Depth 0: main process accepts connection through mTLS
  - Depth 1: forked worker accepts its own connection — mTLS inherited                                                                                                                 
  - Depth 2: worker spawns another worker — mTLS still active                                                                                                                          
                                                                                                                                                                                       
  ## Files                                                                                                                                                                             
                                                                                                                                                                                       
  demos/mtls-propagation/                                   
    README.md                                                                                                                                                                          
    build.sh                     - Builds mtls-grate, compiles test, generates certs
    run.sh                       - Runs the demo                                                                                                                                       
    mtls_propagation_test.c      - Server+client at 3 fork depths
                                                                                                                                                                                       
  ## Running                                                                                                                                                                           
                                                                                                                                                                                       
  ```bash                                                                                                                                                                              
  bash demos/mtls-propagation/build.sh                                                                                                                                                 
  bash demos/mtls-propagation/run.sh   
```