### PR TITLE
Add write filter ordering demo

### DIFF
--- a/demos/write-filter-ordering/README.md
+++ b/demos/write-filter-ordering/README.md
@@ -1,0 +1,40 @@
+# Write Filter Ordering Demo
+
+Demonstrates how grate composition order changes observable behavior.
+Two independently-written grates — strace-grate and write-filter-grate —
+are composed in both orders without modification.
+
+## Ordering A: strace above write-filter
+
+```
+strace-grate → write-filter-grate → cage
+```
+
+Strace sees ALL attempted writes, including those subsequently denied by
+the write filter. A write to `data.db` appears in the trace log with its
+return value of -EPERM.
+
+## Ordering B: write-filter above strace
+
+```
+write-filter-grate → strace-grate → cage
+```
+
+The write filter denies the `data.db` write before it reaches strace.
+Strace only sees writes that pass the filter. The denied write is
+invisible to it.
+
+## What it tests
+
+1. write to `output.log` — succeeds (allowed by filter)
+2. write to `data.db` — denied with EPERM
+3. pwrite to `data.db` — also denied
+4. write to `another.log` — succeeds
+5. read from `data.db` — not blocked (only writes are filtered)
+
+## Running
+
+```bash
+bash demos/write-filter-ordering/build.sh
+bash demos/write-filter-ordering/run.sh
+```

--- a/demos/write-filter-ordering/build.sh
+++ b/demos/write-filter-ordering/build.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#
+# Build everything needed for the write filter ordering demo.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+echo "=== Building Write Filter Ordering Demo ==="
+
+echo "Building strace-grate (Rust, --release)..."
+(cd "$REPO_ROOT/rust-grates/strace-grate" && cargo lind_compile --release --output-dir grates)
+
+echo "Building write-filter-grate (--release)..."
+(cd "$REPO_ROOT/rust-grates/write-filter-grate" && cargo lind_compile --release --output-dir grates)
+
+echo "Compiling test..."
+lind-clang -s "$SCRIPT_DIR/write_filter_ordering_test.c"
+
+echo "Done."

--- a/demos/write-filter-ordering/run.sh
+++ b/demos/write-filter-ordering/run.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# Run the write filter ordering demo.
+# Shows how composition order changes observable behavior.
+# Run build.sh first.
+
+set -euo pipefail
+
+echo "============================================================"
+echo "  Ordering A: strace ABOVE write-filter"
+echo "  strace sees ALL writes, including denied ones"
+echo "============================================================"
+echo ""
+
+lind-wasm grates/strace-grate.cwasm \
+  grates/write-filter-grate.cwasm \
+  write_filter_ordering_test.cwasm
+
+echo ""
+echo "============================================================"
+echo "  Ordering B: write-filter ABOVE strace"
+echo "  strace sees ONLY permitted writes"
+echo "============================================================"
+echo ""
+
+lind-wasm grates/write-filter-grate.cwasm \
+  grates/strace-grate.cwasm \
+  write_filter_ordering_test.cwasm
+
+echo ""
+echo "============================================================"
+echo "  Compare the strace output between orderings."
+echo "  In A, write(data.db) appears in the trace (then denied)."
+echo "  In B, write(data.db) never reaches strace."
+echo "============================================================"

--- a/demos/write-filter-ordering/write_filter_ordering_test.c
+++ b/demos/write-filter-ordering/write_filter_ordering_test.c
@@ -1,0 +1,102 @@
+/*
+ * Write filter + strace composition ordering demo.
+ *
+ * The test program attempts writes to both allowed (.log) and denied
+ * (.db) files. The composition order of strace-grate and write-filter-grate
+ * determines what appears in the trace.
+ *
+ * Ordering A (strace above write-filter):
+ *   strace sees ALL attempted writes, including denied ones.
+ *
+ * Ordering B (write-filter above strace):
+ *   strace sees ONLY permitted writes. Denied writes never reach strace.
+ *
+ * This test verifies:
+ * 1. write to output.log succeeds (allowed by write-filter)
+ * 2. write to data.db fails with EPERM (denied by write-filter)
+ * 3. pwrite to data.db also fails with EPERM
+ * 4. write to another.log succeeds
+ *
+ * Run this under both orderings and compare the strace output.
+ */
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+static int tests_run = 0;
+static int tests_passed = 0;
+
+#define CHECK(name, expr) do { \
+    tests_run++; \
+    if (expr) { printf("  PASS: %s\n", name); tests_passed++; } \
+    else { printf("  FAIL: %s (errno=%d %s)\n", name, errno, strerror(errno)); } \
+} while (0)
+
+int main(void) {
+    printf("=== Write Filter Ordering Demo ===\n\n");
+
+    int fd;
+    ssize_t ret;
+
+    /* Test 1: write to .log file — should succeed */
+    printf("[test_allowed_write]\n");
+    fd = open("output.log", O_CREAT | O_WRONLY | O_TRUNC, 0644);
+    CHECK("open output.log", fd >= 0);
+    if (fd >= 0) {
+        ret = write(fd, "log entry 1\n", 12);
+        CHECK("write to output.log succeeds", ret == 12);
+        close(fd);
+    }
+
+    /* Test 2: write to .db file — should be denied with EPERM */
+    printf("\n[test_denied_write]\n");
+    fd = open("data.db", O_CREAT | O_WRONLY | O_TRUNC, 0644);
+    CHECK("open data.db", fd >= 0);
+    if (fd >= 0) {
+        errno = 0;
+        ret = write(fd, "secret data\n", 12);
+        CHECK("write to data.db denied (EPERM)", ret == -1 && errno == EPERM);
+        close(fd);
+    }
+
+    /* Test 3: pwrite to .db file — also denied */
+    printf("\n[test_denied_pwrite]\n");
+    fd = open("data.db", O_CREAT | O_WRONLY | O_TRUNC, 0644);
+    CHECK("open data.db for pwrite", fd >= 0);
+    if (fd >= 0) {
+        errno = 0;
+        ret = pwrite(fd, "secret pwrite\n", 14, 0);
+        CHECK("pwrite to data.db denied (EPERM)", ret == -1 && errno == EPERM);
+        close(fd);
+    }
+
+    /* Test 4: write to another .log file — should succeed */
+    printf("\n[test_another_allowed]\n");
+    fd = open("another.log", O_CREAT | O_WRONLY | O_TRUNC, 0644);
+    CHECK("open another.log", fd >= 0);
+    if (fd >= 0) {
+        ret = write(fd, "log entry 2\n", 12);
+        CHECK("write to another.log succeeds", ret == 12);
+        close(fd);
+    }
+
+    /* Test 5: read from .db file — should work (only writes are filtered) */
+    printf("\n[test_read_not_filtered]\n");
+    fd = open("data.db", O_RDONLY);
+    if (fd >= 0) {
+        char buf[64] = {0};
+        ret = read(fd, buf, sizeof(buf));
+        CHECK("read from data.db not blocked", ret >= 0);
+        close(fd);
+    }
+
+    /* Cleanup */
+    unlink("output.log");
+    unlink("data.db");
+    unlink("another.log");
+
+    printf("\n=== Result: %d/%d passed ===\n", tests_passed, tests_run);
+    return (tests_passed == tests_run) ? 0 : 1;
+}


### PR DESCRIPTION
  ## Summary                                                                                                                                                                           
                                                                                                                                                                                       
  Demonstrates how grate composition order changes observable behavior.                                                                                                                
  Two independently-written grates — strace-grate and write-filter-grate —                                                                                                             
  are composed in both orders without modification.                                                                                                                                    
                                                                                                                                                                                       
  **Ordering A** (strace above write-filter): strace sees all attempted                                                                                                                
  writes, including those denied by the filter. A write to `data.db`
  appears in the trace with return value -EPERM.
                                                                                                                                                                                       
  **Ordering B** (write-filter above strace): the filter denies the
  `data.db` write before it reaches strace. The denied write is invisible                                                                                                              
  in the trace. Only permitted writes to `.log` files appear.                                                                                                                          
                                              
  Neither grate was written to work with the other. The difference in                                                                                                                  
  observable behavior emerges entirely from composition order.
                                                                                                                                                                                       
  ## Files                                                                                                                                                                             
                                                                                                                                                                                       
  demos/write-filter-ordering/                                                                                                                                                         
    README.md                                               
    build.sh                           - Builds strace + write-filter grates
    run.sh                             - Runs both orderings back to back                                                                                                              
    write_filter_ordering_test.c       - Writes to .log (allowed) and .db (denied)
                                                                                                                                                                                       
  ## Running                                                                                                                                                                           
                                              
  ```bash                                                                                                                                                                              
  bash demos/write-filter-ordering/build.sh                 
  bash demos/write-filter-ordering/run.sh     