### PR TITLE
Ratelimit demo

### DIFF
--- a/demos/rate-limit-clamping/README.md
+++ b/demos/rate-limit-clamping/README.md
@@ -1,0 +1,33 @@
+# Rate-Limit Clamping Demo
+
+Demonstrates scoping a rate limit to a specific port using grate composition.
+The resource-grate enforces a bytes-per-second budget, and the
+net-namespace-grate routes only port 5432 traffic through it. Local file
+I/O is unaffected.
+
+No existing mechanism can scope a rate limit this precisely within a single
+process. The resource-grate was written with no knowledge of
+net-namespace-grate — neither required modification to enable the composition.
+
+## Composition
+
+```
+net-namespace-grate --ports 5432-5432
+  -> resource-grate (50 KB/s netsend limit)
+Host kernel (everything outside port 5432)
+```
+
+## What it tests
+
+1. **File writes**: 200KB written at full speed (~instant)
+2. **Socket writes to port 5432**: 200KB throttled to 50 KB/s (~4 seconds)
+
+The difference in throughput proves that the rate limit is scoped to the
+clamped port range and does not affect other I/O.
+
+## Running
+
+```bash
+bash demos/rate-limit-clamping/build.sh
+bash demos/rate-limit-clamping/run.sh
+```

--- a/demos/rate-limit-clamping/build.sh
+++ b/demos/rate-limit-clamping/build.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# Build everything needed for the rate-limit clamping demo.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+LINDFS="${LINDFS:-${LIND_WASM_ROOT:-$HOME/lind-wasm}/lindfs}"
+
+echo "=== Building Rate-Limit Clamping Demo ==="
+
+echo "Building net-namespace-grate (--release)..."
+(cd "$REPO_ROOT/rust-grates/net-namespace-grate" && cargo lind_compile --release --output-dir grates)
+
+# resource-grate is built without --release because the busy-wait
+# rate limiter loop gets partially optimized out in release mode.
+echo "Building resource-grate..."
+(cd "$REPO_ROOT/rust-grates/resource-grate" && cargo lind_compile --output-dir grates)
+
+echo "Compiling test..."
+lind-clang -s "$SCRIPT_DIR/ratelimit_demo.c"
+
+# Copy config to lindfs
+cp "$SCRIPT_DIR/ratelimit_demo.cfg" "$LINDFS/"
+
+echo "Done."

--- a/demos/rate-limit-clamping/ratelimit_demo.c
+++ b/demos/rate-limit-clamping/ratelimit_demo.c
@@ -1,0 +1,187 @@
+/*
+ * Rate-limit clamping demo.
+ *
+ * net-namespace-grate routes port 5432 through resource-grate (rate limiter).
+ * File I/O is unaffected because it doesn't go through the clamped grate.
+ *
+ * Usage:
+ *   lind-wasm grates/net-namespace-grate.cwasm --ports 5432-5432 %{ \
+ *     grates/resource-grate.cwasm ratelimit_demo.cfg \
+ *   %} ratelimit_demo.cwasm
+ */
+#include <errno.h>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+#define WRITE_SIZE 4096
+#define NUM_WRITES 50
+#define TOTAL_BYTES (WRITE_SIZE * NUM_WRITES)
+
+static double elapsed_sec(struct timespec *start, struct timespec *end) {
+    return (end->tv_sec - start->tv_sec)
+         + (end->tv_nsec - start->tv_nsec) / 1e9;
+}
+
+static double file_throughput = 0;
+static double socket_throughput = 0;
+
+static void test_file_write(void) {
+    printf("=== File I/O (no rate limit) ===\n");
+
+    int fd = open("/tmp/ratelimit_demo.tmp", O_CREAT | O_WRONLY | O_TRUNC, 0644);
+    if (fd < 0) {
+        printf("  SKIP: open failed (errno=%d)\n", errno);
+        return;
+    }
+
+    char buf[WRITE_SIZE];
+    memset(buf, 'F', sizeof(buf));
+
+    struct timespec start, end;
+    clock_gettime(CLOCK_MONOTONIC, &start);
+
+    for (int i = 0; i < NUM_WRITES; i++) {
+        if (write(fd, buf, sizeof(buf)) != sizeof(buf)) {
+            printf("  write failed at i=%d (errno=%d)\n", i, errno);
+            break;
+        }
+    }
+
+    clock_gettime(CLOCK_MONOTONIC, &end);
+    double dt = elapsed_sec(&start, &end);
+    file_throughput = (TOTAL_BYTES / 1024.0) / dt;
+
+    close(fd);
+    unlink("/tmp/ratelimit_demo.tmp");
+
+    printf("  Wrote %d bytes in %.3fs (%.0f KB/s)\n", TOTAL_BYTES, dt, file_throughput);
+}
+
+static void test_socket_write(void) {
+    printf("\n=== Socket write to port 5432 (rate-limited) ===\n");
+
+    int server = socket(AF_INET, SOCK_STREAM, 0);
+    if (server < 0) {
+        printf("  SKIP: socket failed (errno=%d)\n", errno);
+        return;
+    }
+
+    int optval = 1;
+    setsockopt(server, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval));
+
+    struct sockaddr_in addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(5432);
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+
+    if (bind(server, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+        printf("  SKIP: bind failed (errno=%d)\n", errno);
+        close(server);
+        return;
+    }
+
+    if (listen(server, 1) < 0) {
+        printf("  SKIP: listen failed (errno=%d)\n", errno);
+        close(server);
+        return;
+    }
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        printf("  SKIP: fork failed\n");
+        close(server);
+        return;
+    }
+
+    if (pid == 0) {
+        close(server);
+
+        int client = socket(AF_INET, SOCK_STREAM, 0);
+        if (connect(client, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+            _exit(1);
+        }
+
+        char buf[WRITE_SIZE];
+        memset(buf, 'N', sizeof(buf));
+
+        struct timespec start, end;
+        clock_gettime(CLOCK_MONOTONIC, &start);
+
+        for (int i = 0; i < NUM_WRITES; i++) {
+            ssize_t n = write(client, buf, sizeof(buf));
+            if (n <= 0) break;
+        }
+
+        clock_gettime(CLOCK_MONOTONIC, &end);
+        double dt = elapsed_sec(&start, &end);
+        double tp = (TOTAL_BYTES / 1024.0) / dt;
+
+        printf("  Wrote %d bytes in %.3fs (%.0f KB/s)\n", TOTAL_BYTES, dt, tp);
+
+        /* Write throughput to a temp file so parent can read it */
+        int tfd = open("/tmp/ratelimit_tp.tmp", O_CREAT | O_WRONLY | O_TRUNC, 0644);
+        if (tfd >= 0) {
+            char tbuf[32];
+            int tlen = snprintf(tbuf, sizeof(tbuf), "%.2f", tp);
+            write(tfd, tbuf, tlen);
+            close(tfd);
+        }
+
+        close(client);
+        _exit(0);
+    }
+
+    int conn = accept(server, NULL, NULL);
+    if (conn >= 0) {
+        char drain[8192];
+        while (read(conn, drain, sizeof(drain)) > 0) {}
+        close(conn);
+    }
+
+    int status;
+    waitpid(pid, &status, 0);
+    close(server);
+
+    /* Read child's throughput */
+    int tfd = open("/tmp/ratelimit_tp.tmp", O_RDONLY);
+    if (tfd >= 0) {
+        char tbuf[32] = {0};
+        read(tfd, tbuf, sizeof(tbuf) - 1);
+        close(tfd);
+        unlink("/tmp/ratelimit_tp.tmp");
+        sscanf(tbuf, "%lf", &socket_throughput);
+    }
+}
+
+int main(void) {
+    test_file_write();
+    test_socket_write();
+
+    printf("\n=== Results ===\n");
+    printf("  File I/O:     %.0f KB/s\n", file_throughput);
+    printf("  Socket (5432): %.0f KB/s\n", socket_throughput);
+
+    if (file_throughput > 0 && socket_throughput > 0) {
+        double ratio = file_throughput / socket_throughput;
+        double reduction = (1.0 - socket_throughput / file_throughput) * 100.0;
+        printf("  Slowdown:      %.1fx slower\n", ratio);
+        printf("  Reduction:     %.1f%%\n", reduction);
+
+        if (reduction > 50.0) {
+            printf("  PASS: socket writes significantly throttled\n");
+        } else if (reduction > 10.0) {
+            printf("  PASS: socket writes measurably throttled\n");
+        } else {
+            printf("  FAIL: socket writes not throttled (rate limiting not working)\n");
+        }
+    }
+
+    return 0;
+}

--- a/demos/rate-limit-clamping/ratelimit_demo.cfg
+++ b/demos/rate-limit-clamping/ratelimit_demo.cfg
@@ -1,0 +1,6 @@
+# Resource config for the rate-limit demo.
+# Only limits network send rate — file I/O resources are not configured
+# so they're unlimited.
+
+resource netsend 50000          # 50 KB/sec — low enough to see throttling
+resource netrecv 1000000        # 1 MB/sec (generous, not the bottleneck)

--- a/demos/rate-limit-clamping/run.sh
+++ b/demos/rate-limit-clamping/run.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+#
+# Run the rate-limit clamping demo.
+# Run build.sh first.
+
+set -euo pipefail
+
+echo "=== Rate-Limit Clamping Demo ==="
+echo ""
+echo "Composition:"
+echo "  net-namespace-grate --ports 5432-5432"
+echo "    -> resource-grate (50 KB/s network rate limit)"
+echo "  File I/O is NOT rate-limited (bypasses resource-grate)"
+echo ""
+echo "Expected: file writes are fast, socket writes to port 5432 are throttled."
+echo ""
+
+lind-wasm grates/net-namespace-grate.cwasm --ports 5432-5432 %{ \
+  grates/resource-grate.cwasm ratelimit_demo.cfg \
+%} ratelimit_demo.cwasm


### PR DESCRIPTION
  ## Summary                                                                                                                                                                           
                                                                                                                                                                                       
  Demonstrates scoping a network rate limit to a specific port using                                                                                                                   
  grate composition. The net-namespace-grate routes only port 5432                                                                                                                     
  traffic through the resource-grate (50 KB/s netsend limit). File                                                                                                                     
  I/O bypasses the resource-grate and runs at full speed.                                                                                                                              
                                                            
  The test writes 200KB to a file and 200KB to a socket on port 5432,                                                                                                                  
  then compares throughput and reports the slowdown as a percentage.                                                                                                                   
                                                                                                                                                                                       
  Note: resource-grate is built without --release because the                                                                                                                          
  busy-wait rate limiter loop gets partially optimized out in release                                                                                                                  
  mode.                                                                                                                                                                                
                                                            
  ## Files                                                                                                                                                                             
                                                                                                                                                                                       
  demos/rate-limit-clamping/
    README.md                                                                                                                                                                          
    build.sh                  - Builds both grates, compiles test, copies config
    run.sh                    - Runs the composition
    ratelimit_demo.c          - File write vs socket write with throughput comparison
    ratelimit_demo.cfg        - 50 KB/s netsend limit
                                                                                                                                                                                       
  ## Running                              
                                                                                                                                                                                       
  ```bash                                                                                                                                                                              
  bash demos/rate-limit-clamping/build.sh                                                                                                                                              
  bash demos/rate-limit-clamping/run.sh  