### PR TITLE
Fs view grate

### DIFF
--- a/rust-grates/fs-view-grate/Cargo.toml
+++ b/rust-grates/fs-view-grate/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "fs-view-grate"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+grate-rs = { git = "https://github.com/Lind-Project/lind-wasm-example-grates", branch = "main", subdir = "lib/grate-rs" }
+libc = "0.2"

--- a/rust-grates/fs-view-grate/README.md
+++ b/rust-grates/fs-view-grate/README.md
@@ -1,0 +1,29 @@
+# fs-view-grate
+
+Provides per-cage filesystem isolation by transparently prefixing all paths
+with `/cage-<id>/`. Each cage sees its own filesystem namespace — two cages
+opening `/tmp/foo` access completely independent files.
+
+Designed to be composed with imfs-grate or any filesystem grate:
+
+```bash
+lind-wasm grates/namespace-grate.cwasm --prefix /tmp %{ \
+  grates/fs-view-grate.cwasm \
+  grates/imfs-grate.cwasm \
+%} my-program.cwasm
+```
+
+Cage 3 opening `/tmp/foo` → fs-view rewrites to `/cage-3/tmp/foo` → imfs stores it.
+Cage 4 opening `/tmp/foo` → fs-view rewrites to `/cage-4/tmp/foo` → independent file.
+
+## Intercepted syscalls
+
+open, stat, access, mkdir, rmdir, unlink, unlinkat, chmod, truncate,
+chdir, readlink, rename, link, fork, exec
+
+## Building
+
+```bash
+cd rust-grates/fs-view-grate
+cargo lind_compile --output-dir grates
+```

--- a/rust-grates/fs-view-grate/src/main.rs
+++ b/rust-grates/fs-view-grate/src/main.rs
@@ -1,0 +1,245 @@
+//! fs-view-grate: per-cage filesystem views.
+//!
+//! Intercepts path-based syscalls and prefixes every path with /cage-<id>/,
+//! giving each cage its own isolated filesystem namespace. When composed
+//! with imfs-grate, each cage gets an independent in-memory filesystem.
+//!
+//! Usage: fs-view-grate <program> [args...]
+
+use grate_rs::constants::*;
+use grate_rs::constants::lind::GRATE_MEMORY_FLAG;
+use grate_rs::{GrateBuilder, GrateError, copy_data_between_cages, getcageid, is_thread_clone, make_threei_call};
+
+use std::ffi::CString;
+
+const MAX_PATH: usize = 4096;
+
+/// Read a NUL-terminated path from cage memory.
+fn read_path(ptr: u64, cage: u64) -> Option<String> {
+    let grate = getcageid();
+    let mut buf = vec![0u8; MAX_PATH];
+    copy_data_between_cages(
+        grate, cage, ptr, cage,
+        buf.as_mut_ptr() as u64, grate,
+        MAX_PATH as u64, 0,
+    ).ok()?;
+    let len = buf.iter().position(|&b| b == 0).unwrap_or(MAX_PATH);
+    Some(String::from_utf8_lossy(&buf[..len]).to_string())
+}
+
+/// Rewrite a path by prefixing with /cage-<id>.
+fn cage_path(path: &str, cage_id: u64) -> String {
+    format!("/cage-{}{}", cage_id, if path.starts_with('/') { path.to_string() } else { format!("/{}", path) })
+}
+
+/// Forward a syscall, rewriting arg at `path_idx` with the cage-prefixed path.
+fn forward_with_rewrite(
+    nr: u64, cage_id: u64,
+    args: &[u64; 6], arg_cages: &[u64; 6],
+    path_idx: usize, new_path: &CString,
+) -> i32 {
+    let grate = getcageid();
+    let mut a = *args;
+    let mut c = *arg_cages;
+    a[path_idx] = new_path.as_ptr() as u64;
+    c[path_idx] = grate | GRATE_MEMORY_FLAG;
+
+    match make_threei_call(
+        nr as u32, 0, grate, cage_id,
+        a[0], c[0], a[1], c[1], a[2], c[2],
+        a[3], c[3], a[4], c[4], a[5], c[5], 0,
+    ) {
+        Ok(r) => r,
+        Err(_) => -1,
+    }
+}
+
+/// Forward a syscall without rewriting.
+fn forward(nr: u64, cage_id: u64, args: &[u64; 6], arg_cages: &[u64; 6]) -> i32 {
+    let grate = getcageid();
+    match make_threei_call(
+        nr as u32, 0, grate, cage_id,
+        args[0], arg_cages[0], args[1], arg_cages[1], args[2], arg_cages[2],
+        args[3], arg_cages[3], args[4], arg_cages[4], args[5], arg_cages[5], 0,
+    ) {
+        Ok(r) => r,
+        Err(_) => -1,
+    }
+}
+
+/// Ensure the per-cage root directory exists (e.g. /cage-3).
+fn ensure_cage_root(cage_id: u64) {
+    let root = format!("/cage-{}", cage_id);
+    let c_root = CString::new(root).unwrap();
+    let grate = getcageid();
+    let ptr = c_root.as_ptr() as u64;
+    // mkdir with 0755 — ignore errors (already exists is fine)
+    let _ = make_threei_call(
+        SYS_MKDIR as u32, 0, grate, cage_id,
+        ptr, grate | GRATE_MEMORY_FLAG,
+        0o755, cage_id,
+        0, 0, 0, 0, 0, 0, 0, 0, 0,
+    );
+}
+
+// Generate a handler that rewrites the path at a given arg index.
+macro_rules! path_rewrite_handler {
+    ($name:ident, $sysno:expr, $path_idx:expr) => {
+        pub extern "C" fn $name(
+            _cageid: u64,
+            arg1: u64, arg1cage: u64,
+            arg2: u64, arg2cage: u64,
+            arg3: u64, arg3cage: u64,
+            arg4: u64, arg4cage: u64,
+            arg5: u64, arg5cage: u64,
+            arg6: u64, arg6cage: u64,
+        ) -> i32 {
+            let args = [arg1, arg2, arg3, arg4, arg5, arg6];
+            let arg_cages = [arg1cage, arg2cage, arg3cage, arg4cage, arg5cage, arg6cage];
+            let cage_id = arg_cages[$path_idx];
+
+            let ptr = args[$path_idx];
+            let cage = arg_cages[$path_idx];
+
+            let path = match read_path(ptr, cage) {
+                Some(p) => p,
+                None => return -14, // EFAULT
+            };
+
+            let rewritten = cage_path(&path, cage_id);
+            let c_path = match CString::new(rewritten) {
+                Ok(p) => p,
+                None => return -1,
+            };
+
+            ensure_cage_root(cage_id);
+            forward_with_rewrite($sysno, cage_id, &args, &arg_cages, $path_idx, &c_path)
+        }
+    };
+}
+
+// Two-path handler (e.g. rename, link)
+macro_rules! two_path_rewrite_handler {
+    ($name:ident, $sysno:expr, $idx1:expr, $idx2:expr) => {
+        pub extern "C" fn $name(
+            _cageid: u64,
+            arg1: u64, arg1cage: u64,
+            arg2: u64, arg2cage: u64,
+            arg3: u64, arg3cage: u64,
+            arg4: u64, arg4cage: u64,
+            arg5: u64, arg5cage: u64,
+            arg6: u64, arg6cage: u64,
+        ) -> i32 {
+            let args = [arg1, arg2, arg3, arg4, arg5, arg6];
+            let arg_cages = [arg1cage, arg2cage, arg3cage, arg4cage, arg5cage, arg6cage];
+            let cage_id = arg_cages[$idx1];
+
+            let path1 = match read_path(args[$idx1], arg_cages[$idx1]) {
+                Some(p) => p,
+                None => return -14,
+            };
+            let path2 = match read_path(args[$idx2], arg_cages[$idx2]) {
+                Some(p) => p,
+                None => return -14,
+            };
+
+            let grate = getcageid();
+            let c1 = match CString::new(cage_path(&path1, cage_id)) {
+                Ok(p) => p,
+                None => return -1,
+            };
+            let c2 = match CString::new(cage_path(&path2, cage_id)) {
+                Ok(p) => p,
+                None => return -1,
+            };
+
+            let mut a = args;
+            let mut c = arg_cages;
+            a[$idx1] = c1.as_ptr() as u64;
+            c[$idx1] = grate | GRATE_MEMORY_FLAG;
+            a[$idx2] = c2.as_ptr() as u64;
+            c[$idx2] = grate | GRATE_MEMORY_FLAG;
+
+            ensure_cage_root(cage_id);
+
+            match make_threei_call(
+                $sysno as u32, 0, grate, cage_id,
+                a[0], c[0], a[1], c[1], a[2], c[2],
+                a[3], c[3], a[4], c[4], a[5], c[5], 0,
+            ) {
+                Ok(r) => r,
+                Err(_) => -1,
+            }
+        }
+    };
+}
+
+path_rewrite_handler!(open_handler, SYS_OPEN, 0);
+path_rewrite_handler!(stat_handler, SYS_XSTAT, 0);
+path_rewrite_handler!(access_handler, SYS_ACCESS, 0);
+path_rewrite_handler!(mkdir_handler, SYS_MKDIR, 0);
+path_rewrite_handler!(rmdir_handler, SYS_RMDIR, 0);
+path_rewrite_handler!(unlink_handler, SYS_UNLINK, 0);
+path_rewrite_handler!(unlinkat_handler, SYS_UNLINKAT, 1);
+path_rewrite_handler!(chmod_handler, SYS_CHMOD, 0);
+path_rewrite_handler!(truncate_handler, SYS_TRUNCATE, 0);
+path_rewrite_handler!(chdir_handler, SYS_CHDIR, 0);
+path_rewrite_handler!(readlink_handler, SYS_READLINK, 0);
+
+two_path_rewrite_handler!(rename_handler, SYS_RENAME, 0, 1);
+two_path_rewrite_handler!(link_handler, SYS_LINK, 0, 1);
+
+pub extern "C" fn fork_handler(
+    _cageid: u64,
+    arg1: u64, arg1cage: u64,
+    arg2: u64, arg2cage: u64,
+    arg3: u64, arg3cage: u64,
+    arg4: u64, arg4cage: u64,
+    arg5: u64, arg5cage: u64,
+    arg6: u64, arg6cage: u64,
+) -> i32 {
+    let args = [arg1, arg2, arg3, arg4, arg5, arg6];
+    let arg_cages = [arg1cage, arg2cage, arg3cage, arg4cage, arg5cage, arg6cage];
+    forward(SYS_CLONE, arg1cage, &args, &arg_cages)
+}
+
+pub extern "C" fn exec_handler(
+    _cageid: u64,
+    arg1: u64, arg1cage: u64,
+    arg2: u64, arg2cage: u64,
+    arg3: u64, arg3cage: u64,
+    arg4: u64, arg4cage: u64,
+    arg5: u64, arg5cage: u64,
+    arg6: u64, arg6cage: u64,
+) -> i32 {
+    let args = [arg1, arg2, arg3, arg4, arg5, arg6];
+    let arg_cages = [arg1cage, arg2cage, arg3cage, arg4cage, arg5cage, arg6cage];
+    forward(SYS_EXEC, arg1cage, &args, &arg_cages)
+}
+
+fn main() {
+    let argv: Vec<String> = std::env::args().skip(1).collect();
+
+    GrateBuilder::new()
+        .register(SYS_OPEN, open_handler)
+        .register(SYS_XSTAT, stat_handler)
+        .register(SYS_ACCESS, access_handler)
+        .register(SYS_MKDIR, mkdir_handler)
+        .register(SYS_RMDIR, rmdir_handler)
+        .register(SYS_UNLINK, unlink_handler)
+        .register(SYS_UNLINKAT, unlinkat_handler)
+        .register(SYS_CHMOD, chmod_handler)
+        .register(SYS_TRUNCATE, truncate_handler)
+        .register(SYS_CHDIR, chdir_handler)
+        .register(SYS_READLINK, readlink_handler)
+        .register(SYS_RENAME, rename_handler)
+        .register(SYS_LINK, link_handler)
+        .register(SYS_CLONE, fork_handler)
+        .register(SYS_EXEC, exec_handler)
+        .teardown(|result: Result<i32, GrateError>| {
+            if let Err(e) = result {
+                eprintln!("[fs-view] error: {:?}", e);
+            }
+        })
+        .run(argv);
+}

--- a/rust-grates/fs-view-grate/src/main.rs
+++ b/rust-grates/fs-view-grate/src/main.rs
@@ -161,15 +161,7 @@ macro_rules! two_path_rewrite_handler {
             c[$idx2] = grate | GRATE_MEMORY_FLAG;
 
             ensure_cage_root(cage_id);
-
-            match make_threei_call(
-                $sysno as u32, 0, grate, cage_id,
-                a[0], c[0], a[1], c[1], a[2], c[2],
-                a[3], c[3], a[4], c[4], a[5], c[5], 0,
-            ) {
-                Ok(r) => r,
-                Err(_) => -1,
-            }
+            forward($sysno, cage_id, &a, &c)
         }
     };
 }

--- a/rust-grates/fs-view-grate/src/main.rs
+++ b/rust-grates/fs-view-grate/src/main.rs
@@ -161,7 +161,15 @@ macro_rules! two_path_rewrite_handler {
             c[$idx2] = grate | GRATE_MEMORY_FLAG;
 
             ensure_cage_root(cage_id);
-            forward($sysno, cage_id, &a, &c)
+
+            match make_threei_call(
+                $sysno as u32, 0, grate, cage_id,
+                a[0], c[0], a[1], c[1], a[2], c[2],
+                a[3], c[3], a[4], c[4], a[5], c[5], 0,
+            ) {
+                Ok(r) => r,
+                Err(_) => -1,
+            }
         }
     };
 }

--- a/rust-grates/fs-view-grate/src/main.rs
+++ b/rust-grates/fs-view-grate/src/main.rs
@@ -8,7 +8,7 @@
 
 use grate_rs::constants::*;
 use grate_rs::constants::lind::GRATE_MEMORY_FLAG;
-use grate_rs::{GrateBuilder, GrateError, copy_data_between_cages, getcageid, is_thread_clone, make_threei_call};
+use grate_rs::{GrateBuilder, GrateError, copy_data_between_cages, getcageid, make_threei_call};
 
 use std::ffi::CString;
 
@@ -109,7 +109,7 @@ macro_rules! path_rewrite_handler {
             let rewritten = cage_path(&path, cage_id);
             let c_path = match CString::new(rewritten) {
                 Ok(p) => p,
-                None => return -1,
+                Err(_) => return -1,
             };
 
             ensure_cage_root(cage_id);
@@ -146,11 +146,11 @@ macro_rules! two_path_rewrite_handler {
             let grate = getcageid();
             let c1 = match CString::new(cage_path(&path1, cage_id)) {
                 Ok(p) => p,
-                None => return -1,
+                Err(_) => return -1,
             };
             let c2 = match CString::new(cage_path(&path2, cage_id)) {
                 Ok(p) => p,
-                None => return -1,
+                Err(_) => return -1,
             };
 
             let mut a = args;

--- a/rust-grates/fs-view-grate/test/fs_view_test.c
+++ b/rust-grates/fs-view-grate/test/fs_view_test.c
@@ -1,0 +1,95 @@
+/*
+ * Basic fs-view-grate test.
+ *
+ * Verifies that each cage gets its own filesystem view via path prefixing.
+ * Uses the host filesystem (no imfs). Parent and child both write to /tmp/foo
+ * and each should see their own file at /cage-<id>/tmp/foo on the host.
+ *
+ * Usage: lind-wasm grates/fs-view-grate.cwasm fs_view_test.cwasm
+ */
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+static int tests_run = 0;
+static int tests_passed = 0;
+
+#define CHECK(name, expr) do { \
+    tests_run++; \
+    if (expr) { printf("  PASS: %s\n", name); tests_passed++; } \
+    else { printf("  FAIL: %s (errno=%d %s)\n", name, errno, strerror(errno)); } \
+} while (0)
+
+int main(void) {
+    printf("=== fs-view-grate test ===\n");
+
+    /* Create /tmp in our cage view */
+    mkdir("/tmp", 0755);
+
+    /* Parent writes to /tmp/foo */
+    printf("\n[parent]\n");
+    int fd = open("/tmp/foo.txt", O_CREAT | O_RDWR | O_TRUNC, 0644);
+    CHECK("parent: create /tmp/foo.txt", fd >= 0);
+    if (fd >= 0) {
+        write(fd, "parent", 6);
+        close(fd);
+    }
+
+    /* Fork child */
+    pid_t pid = fork();
+    if (pid == 0) {
+        printf("\n[child]\n");
+
+        /* Child creates its own /tmp */
+        mkdir("/tmp", 0755);
+
+        /* Child writes to /tmp/foo — should be independent */
+        int cfd = open("/tmp/foo.txt", O_CREAT | O_RDWR | O_TRUNC, 0644);
+        if (cfd < 0) {
+            printf("  FAIL: child open (errno=%d)\n", errno);
+            _exit(1);
+        }
+        write(cfd, "child", 5);
+        close(cfd);
+
+        /* Child reads back — should see "child" not "parent" */
+        cfd = open("/tmp/foo.txt", O_RDONLY);
+        if (cfd < 0) _exit(1);
+        char buf[32] = {0};
+        ssize_t n = read(cfd, buf, sizeof(buf) - 1);
+        close(cfd);
+
+        if (n == 5 && memcmp(buf, "child", 5) == 0) {
+            printf("  PASS: child sees own data\n");
+        } else {
+            printf("  FAIL: child sees '%s' (expected 'child')\n", buf);
+            _exit(1);
+        }
+
+        _exit(0);
+    }
+
+    int status;
+    waitpid(pid, &status, 0);
+    CHECK("child exited cleanly", WIFEXITED(status) && WEXITSTATUS(status) == 0);
+
+    /* Parent reads back — should still see "parent" */
+    fd = open("/tmp/foo.txt", O_RDONLY);
+    CHECK("parent: reopen /tmp/foo.txt", fd >= 0);
+    if (fd >= 0) {
+        char buf[32] = {0};
+        ssize_t n = read(fd, buf, sizeof(buf) - 1);
+        close(fd);
+        CHECK("parent: still sees 'parent'", n == 6 && memcmp(buf, "parent", 6) == 0);
+    }
+
+    /* Cleanup */
+    unlink("/tmp/foo.txt");
+
+    printf("\n=== Result: %d/%d passed ===\n", tests_passed, tests_run);
+    return (tests_passed == tests_run) ? 0 : 1;
+}

--- a/rust-grates/fs-view-grate/test/fs_view_test.c
+++ b/rust-grates/fs-view-grate/test/fs_view_test.c
@@ -1,9 +1,8 @@
 /*
- * Basic fs-view-grate test.
+ * fs-view-grate test suite.
  *
- * Verifies that each cage gets its own filesystem view via path prefixing.
- * Uses the host filesystem (no imfs). Parent and child both write to /tmp/foo
- * and each should see their own file at /cage-<id>/tmp/foo on the host.
+ * Verifies per-cage filesystem isolation via path prefixing.
+ * Each cage sees its own /cage-<id>/ namespace on the host.
  *
  * Usage: lind-wasm grates/fs-view-grate.cwasm fs_view_test.cwasm
  */
@@ -24,71 +23,290 @@ static int tests_passed = 0;
     else { printf("  FAIL: %s (errno=%d %s)\n", name, errno, strerror(errno)); } \
 } while (0)
 
-int main(void) {
-    printf("=== fs-view-grate test ===\n");
+/* ================================================================
+ * Test 1: Basic write isolation — parent and child write to same
+ * path, each sees only their own data.
+ * ================================================================ */
+static void test_write_isolation(void) {
+    printf("\n[test_write_isolation]\n");
 
-    /* Create /tmp in our cage view */
     mkdir("/tmp", 0755);
 
-    /* Parent writes to /tmp/foo */
-    printf("\n[parent]\n");
-    int fd = open("/tmp/foo.txt", O_CREAT | O_RDWR | O_TRUNC, 0644);
-    CHECK("parent: create /tmp/foo.txt", fd >= 0);
+    /* Parent writes */
+    int fd = open("/tmp/shared_name.txt", O_CREAT | O_RDWR | O_TRUNC, 0644);
+    CHECK("parent: create /tmp/shared_name.txt", fd >= 0);
     if (fd >= 0) {
-        write(fd, "parent", 6);
+        write(fd, "PARENT_DATA", 11);
         close(fd);
     }
 
-    /* Fork child */
     pid_t pid = fork();
     if (pid == 0) {
-        printf("\n[child]\n");
-
-        /* Child creates its own /tmp */
         mkdir("/tmp", 0755);
 
-        /* Child writes to /tmp/foo — should be independent */
-        int cfd = open("/tmp/foo.txt", O_CREAT | O_RDWR | O_TRUNC, 0644);
-        if (cfd < 0) {
-            printf("  FAIL: child open (errno=%d)\n", errno);
-            _exit(1);
-        }
-        write(cfd, "child", 5);
+        /* Child writes different data to same path */
+        int cfd = open("/tmp/shared_name.txt", O_CREAT | O_RDWR | O_TRUNC, 0644);
+        if (cfd < 0) _exit(1);
+        write(cfd, "CHILD_DATA", 10);
         close(cfd);
 
-        /* Child reads back — should see "child" not "parent" */
-        cfd = open("/tmp/foo.txt", O_RDONLY);
+        /* Child reads back — must see CHILD_DATA */
+        cfd = open("/tmp/shared_name.txt", O_RDONLY);
         if (cfd < 0) _exit(1);
         char buf[32] = {0};
-        ssize_t n = read(cfd, buf, sizeof(buf) - 1);
+        read(cfd, buf, sizeof(buf) - 1);
         close(cfd);
 
-        if (n == 5 && memcmp(buf, "child", 5) == 0) {
-            printf("  PASS: child sees own data\n");
+        if (memcmp(buf, "CHILD_DATA", 10) == 0) {
+            printf("  PASS: child reads back CHILD_DATA\n");
+            _exit(0);
         } else {
-            printf("  FAIL: child sees '%s' (expected 'child')\n", buf);
+            printf("  FAIL: child reads '%s' (expected CHILD_DATA)\n", buf);
             _exit(1);
         }
-
-        _exit(0);
     }
 
     int status;
     waitpid(pid, &status, 0);
-    CHECK("child exited cleanly", WIFEXITED(status) && WEXITSTATUS(status) == 0);
+    CHECK("child verified isolation", WIFEXITED(status) && WEXITSTATUS(status) == 0);
 
-    /* Parent reads back — should still see "parent" */
-    fd = open("/tmp/foo.txt", O_RDONLY);
-    CHECK("parent: reopen /tmp/foo.txt", fd >= 0);
+    /* Parent reads back — must still see PARENT_DATA */
+    fd = open("/tmp/shared_name.txt", O_RDONLY);
+    CHECK("parent: reopen", fd >= 0);
     if (fd >= 0) {
         char buf[32] = {0};
-        ssize_t n = read(fd, buf, sizeof(buf) - 1);
+        read(fd, buf, sizeof(buf) - 1);
         close(fd);
-        CHECK("parent: still sees 'parent'", n == 6 && memcmp(buf, "parent", 6) == 0);
+        CHECK("parent: still reads PARENT_DATA", memcmp(buf, "PARENT_DATA", 11) == 0);
     }
 
-    /* Cleanup */
-    unlink("/tmp/foo.txt");
+    unlink("/tmp/shared_name.txt");
+}
+
+/* ================================================================
+ * Test 2: Directory isolation — parent mkdir is not visible to child.
+ * ================================================================ */
+static void test_directory_isolation(void) {
+    printf("\n[test_directory_isolation]\n");
+
+    mkdir("/tmp", 0755);
+    int ret = mkdir("/tmp/parent_dir", 0755);
+    CHECK("parent: mkdir /tmp/parent_dir", ret == 0 || errno == EEXIST);
+
+    /* Create a file inside the dir */
+    int fd = open("/tmp/parent_dir/file.txt", O_CREAT | O_WRONLY | O_TRUNC, 0644);
+    CHECK("parent: create file in parent_dir", fd >= 0);
+    if (fd >= 0) {
+        write(fd, "in_parent_dir", 13);
+        close(fd);
+    }
+
+    pid_t pid = fork();
+    if (pid == 0) {
+        mkdir("/tmp", 0755);
+
+        /* Child: /tmp/parent_dir should NOT exist */
+        int cfd = open("/tmp/parent_dir/file.txt", O_RDONLY);
+        if (cfd >= 0) {
+            printf("  FAIL: child can see parent's /tmp/parent_dir/file.txt\n");
+            close(cfd);
+            _exit(1);
+        }
+        printf("  PASS: child cannot see parent's /tmp/parent_dir\n");
+
+        /* Child creates its own dir with same name */
+        mkdir("/tmp/parent_dir", 0755);
+        cfd = open("/tmp/parent_dir/file.txt", O_CREAT | O_WRONLY | O_TRUNC, 0644);
+        if (cfd < 0) _exit(1);
+        write(cfd, "in_child_dir", 12);
+        close(cfd);
+
+        /* Verify child's file */
+        cfd = open("/tmp/parent_dir/file.txt", O_RDONLY);
+        if (cfd < 0) _exit(1);
+        char buf[32] = {0};
+        read(cfd, buf, sizeof(buf) - 1);
+        close(cfd);
+
+        if (memcmp(buf, "in_child_dir", 12) == 0) {
+            printf("  PASS: child reads own data from /tmp/parent_dir/file.txt\n");
+            _exit(0);
+        } else {
+            printf("  FAIL: child reads '%s'\n", buf);
+            _exit(1);
+        }
+    }
+
+    int st;
+    waitpid(pid, &st, 0);
+    CHECK("child directory isolation verified", WIFEXITED(st) && WEXITSTATUS(st) == 0);
+
+    /* Parent's file still intact */
+    fd = open("/tmp/parent_dir/file.txt", O_RDONLY);
+    CHECK("parent: file still exists", fd >= 0);
+    if (fd >= 0) {
+        char buf[32] = {0};
+        read(fd, buf, sizeof(buf) - 1);
+        close(fd);
+        CHECK("parent: data still in_parent_dir", memcmp(buf, "in_parent_dir", 13) == 0);
+    }
+
+    unlink("/tmp/parent_dir/file.txt");
+    rmdir("/tmp/parent_dir");
+}
+
+/* ================================================================
+ * Test 3: Multiple files — parent creates several, child sees none.
+ * ================================================================ */
+static void test_multiple_files(void) {
+    printf("\n[test_multiple_files]\n");
+
+    mkdir("/tmp", 0755);
+
+    char path[64];
+    for (int i = 0; i < 5; i++) {
+        snprintf(path, sizeof(path), "/tmp/multi_%d.txt", i);
+        int fd = open(path, O_CREAT | O_WRONLY | O_TRUNC, 0644);
+        if (fd >= 0) {
+            char data[16];
+            int len = snprintf(data, sizeof(data), "file_%d", i);
+            write(fd, data, len);
+            close(fd);
+        }
+    }
+    CHECK("parent: created 5 files", 1);
+
+    pid_t pid = fork();
+    if (pid == 0) {
+        mkdir("/tmp", 0755);
+
+        int visible = 0;
+        for (int i = 0; i < 5; i++) {
+            snprintf(path, sizeof(path), "/tmp/multi_%d.txt", i);
+            int cfd = open(path, O_RDONLY);
+            if (cfd >= 0) {
+                visible++;
+                close(cfd);
+            }
+        }
+
+        if (visible == 0) {
+            printf("  PASS: child sees 0 of parent's 5 files\n");
+            _exit(0);
+        } else {
+            printf("  FAIL: child sees %d of parent's files\n", visible);
+            _exit(1);
+        }
+    }
+
+    int st;
+    waitpid(pid, &st, 0);
+    CHECK("child sees no parent files", WIFEXITED(st) && WEXITSTATUS(st) == 0);
+
+    /* Parent can still read all */
+    int readable = 0;
+    for (int i = 0; i < 5; i++) {
+        snprintf(path, sizeof(path), "/tmp/multi_%d.txt", i);
+        int fd = open(path, O_RDONLY);
+        if (fd >= 0) {
+            readable++;
+            close(fd);
+        }
+    }
+    CHECK("parent: all 5 files still readable", readable == 5);
+
+    for (int i = 0; i < 5; i++) {
+        snprintf(path, sizeof(path), "/tmp/multi_%d.txt", i);
+        unlink(path);
+    }
+}
+
+/* ================================================================
+ * Test 4: Grandchild isolation — three levels of fork, each
+ * independent.
+ * ================================================================ */
+static void test_grandchild_isolation(void) {
+    printf("\n[test_grandchild_isolation]\n");
+
+    mkdir("/tmp", 0755);
+
+    int fd = open("/tmp/depth.txt", O_CREAT | O_WRONLY | O_TRUNC, 0644);
+    if (fd >= 0) { write(fd, "depth0", 6); close(fd); }
+
+    pid_t pid = fork();
+    if (pid == 0) {
+        /* Child (depth 1) */
+        mkdir("/tmp", 0755);
+
+        /* Should not see parent's file */
+        int cfd = open("/tmp/depth.txt", O_RDONLY);
+        if (cfd >= 0) {
+            printf("  FAIL: depth 1 sees parent's /tmp/depth.txt\n");
+            close(cfd);
+            _exit(1);
+        }
+        printf("  PASS: depth 1 cannot see depth 0's file\n");
+
+        cfd = open("/tmp/depth.txt", O_CREAT | O_WRONLY | O_TRUNC, 0644);
+        if (cfd >= 0) { write(cfd, "depth1", 6); close(cfd); }
+
+        pid_t pid2 = fork();
+        if (pid2 == 0) {
+            /* Grandchild (depth 2) */
+            mkdir("/tmp", 0755);
+
+            int gfd = open("/tmp/depth.txt", O_RDONLY);
+            if (gfd >= 0) {
+                printf("  FAIL: depth 2 sees depth 1's /tmp/depth.txt\n");
+                close(gfd);
+                _exit(1);
+            }
+            printf("  PASS: depth 2 cannot see depth 1's file\n");
+            _exit(0);
+        }
+
+        int st2;
+        waitpid(pid2, &st2, 0);
+        if (!WIFEXITED(st2) || WEXITSTATUS(st2) != 0) _exit(1);
+
+        /* Depth 1 can still read its own */
+        cfd = open("/tmp/depth.txt", O_RDONLY);
+        if (cfd < 0) _exit(1);
+        char buf[16] = {0};
+        read(cfd, buf, sizeof(buf) - 1);
+        close(cfd);
+        if (memcmp(buf, "depth1", 6) != 0) _exit(1);
+        printf("  PASS: depth 1 still reads own data\n");
+
+        _exit(0);
+    }
+
+    int st;
+    waitpid(pid, &st, 0);
+    CHECK("grandchild isolation verified", WIFEXITED(st) && WEXITSTATUS(st) == 0);
+
+    /* Depth 0 still has its data */
+    fd = open("/tmp/depth.txt", O_RDONLY);
+    CHECK("depth 0: file still exists", fd >= 0);
+    if (fd >= 0) {
+        char buf[16] = {0};
+        read(fd, buf, sizeof(buf) - 1);
+        close(fd);
+        CHECK("depth 0: reads depth0", memcmp(buf, "depth0", 6) == 0);
+    }
+
+    unlink("/tmp/depth.txt");
+}
+
+/* ================================================================ */
+
+int main(void) {
+    printf("=== fs-view-grate test suite ===\n");
+
+    test_write_isolation();
+    test_directory_isolation();
+    test_multiple_files();
+    test_grandchild_isolation();
 
     printf("\n=== Result: %d/%d passed ===\n", tests_passed, tests_run);
     return (tests_passed == tests_run) ? 0 : 1;

--- a/test/grates_test.toml
+++ b/test/grates_test.toml
@@ -205,6 +205,16 @@ dir = "mtls-grate"
 type = "rust"
 skip = true
 
+# ── fs-view (Rust) ──────────────────────────────────────────────────
+
+[[grate]]
+name = "fs-view-grate"
+dir = "fs-view-grate"
+type = "rust"
+
+[[grate.tests]]
+test_src = "test/fs_view_test.c"
+
 # ── fdtables stress test (Rust) ─────────────────────────────────────
 
 [[grate]]


### PR DESCRIPTION
 ## Summary

  Adds a new grate that provides per-cage filesystem isolation by
  transparently prefixing all paths with `/cage-<id>/`. Two cages
  opening `/tmp/foo` access completely independent files.

  Designed to be composed with namespace-grate + imfs-grate for the
  per-cage /tmp isolation demo in the paper.

  ## How it works

  Every path-based syscall (open, mkdir, stat, unlink, etc.) is
  intercepted. The path is rewritten from `/tmp/foo` to
  `/cage-3/tmp/foo` before forwarding. Each cage's root directory
  is created on first access.

  ## Files

  rust-grates/fs-view-grate/
    Cargo.toml
    README.md
    src/main.rs          - Path-rewriting handlers via macros
    test/fs_view_test.c  - Basic test: parent and child write to
                           same path, each sees only their own data

  ## Running

  ```bash
  cargo lind_compile --output-dir grates
  lind-clang -s test/fs_view_test.c
  lind-wasm grates/fs-view-grate.cwasm fs_view_test.cwasm
