### PR TITLE
IMFS: calling cage fix for open handlers.

### DIFF
--- a/c-grates/imfs-grate/src/imfs-grate.c
+++ b/c-grates/imfs-grate/src/imfs-grate.c
@@ -86,7 +86,11 @@ int open_grate(uint64_t grateid, uint64_t arg1, uint64_t arg1cage,
 	       uint64_t arg5, uint64_t arg5cage, uint64_t arg6,
 	       uint64_t arg6cage) {
 	int thiscage = getpid();
-	int cageid = arg1cage;
+
+	// Represents the calling cage. Using arg2cage instead of arg1cage since
+	// the path pointer may have been modified by a transient grate and
+	// therefore might differ from the original calling cage.
+	int cageid = arg2cage;
 
 	// Copying the char* pathname into the grate's memory.
 	char *pathname = malloc(256);

--- a/c-grates/imfs-grate/src/imfs-grate.c
+++ b/c-grates/imfs-grate/src/imfs-grate.c
@@ -89,7 +89,7 @@ int open_grate(uint64_t grateid, uint64_t arg1, uint64_t arg1cage,
 
 	// Represents the calling cage. Using arg2cage instead of arg1cage since
 	// the path pointer may have been modified by a transient grate and
-	// therefore might differ from the original calling cage.
+	// therefore arg1cage might differ from the original calling cage.
 	int cageid = arg2cage;
 
 	// Copying the char* pathname into the grate's memory.

--- a/rust-grates/imfs-grate/src/handlers.rs
+++ b/rust-grates/imfs-grate/src/handlers.rs
@@ -59,10 +59,11 @@ pub extern "C" fn open_handler(
     _arg6cage: u64,
 ) -> i32 {
     // This represents the calling cage, i.e. the cage that initially called open. Since arg1,
-    // arg1cage represents a path pointer, it might have represent the cageid of a transient grate
+    // arg1cage represents a path pointer, it might represent the cageid of a transient grate
     // that modified this pointer.
     //
-    // We therefore use arg2cage since that represents the `flag` which is an integer pointer.
+    // We therefore use arg2cage since that represents the `flag` which is an integer and won't be
+    // translated.
     let cage_id = arg2cage;
 
     // Copy the pathname from the cage's memory.

--- a/rust-grates/imfs-grate/src/handlers.rs
+++ b/rust-grates/imfs-grate/src/handlers.rs
@@ -48,7 +48,7 @@ pub extern "C" fn open_handler(
     arg1: u64,
     arg1cage: u64,
     arg2: u64,
-    _arg2cage: u64,
+    arg2cage: u64,
     arg3: u64,
     _arg3cage: u64,
     _arg4: u64,
@@ -58,7 +58,12 @@ pub extern "C" fn open_handler(
     _arg6: u64,
     _arg6cage: u64,
 ) -> i32 {
-    let cage_id = arg1cage;
+    // This represents the calling cage, i.e. the cage that initially called open. Since arg1,
+    // arg1cage represents a path pointer, it might have represent the cageid of a transient grate
+    // that modified this pointer.
+    //
+    // We therefore use arg2cage since that represents the `flag` which is an integer pointer.
+    let cage_id = arg2cage;
 
     // Copy the pathname from the cage's memory.
     let pathname = match copy_path_from_cage(arg1, arg1cage) {


### PR DESCRIPTION
Use arg2cage in path instead of arg1cage to represent the calling cage, since arg1, arg1cage might have been modified by a transient grate.