### PR TITLE
Fix namespace-grate fork handling for grate composition

### DIFF
--- a/rust-grates/namespace-grate/src/handlers/clamped_lifecycle.rs
+++ b/rust-grates/namespace-grate/src/handlers/clamped_lifecycle.rs
@@ -224,10 +224,13 @@ pub extern "C" fn fork_handler(
     let child_cage_id = helpers::do_syscall(arg1cage, SYS_CLONE, &args, &arg_cages) as u64;
 
     if !is_thread_clone(arg1, arg1cage) {
-        // If the forking cage is inside the clamp, the child inherits that status.
+        // Copy fdtables — child always needs an entry for inner grates
+        // to track fds, regardless of clamp status.
+        let _ = fdtables::copy_fdtable_for_cage(arg1cage, child_cage_id);
+
+        // If the forking cage is inside the clamp, clone routes too.
         if helpers::is_cage_clamped(arg1cage) {
-            // Copy the fd table so the child knows which fds are clamped.
-            let _ = fdtables::copy_fdtable_for_cage(arg1cage, child_cage_id);
+            helpers::clone_cage_routes(arg1cage, child_cage_id);
         }
 
         // Register our lifecycle handlers on the child so we can track it.

--- a/rust-grates/namespace-grate/src/handlers/ns_handlers.rs
+++ b/rust-grates/namespace-grate/src/handlers/ns_handlers.rs
@@ -359,15 +359,9 @@ pub extern "C" fn ns_clone_handler(
     if !is_thread_clone(arg1, arg1cage) {
         let child_cage_id = ret as u64;
 
-        if fdtables::check_cage_exists(arg1cage) {
-            let _ = fdtables::copy_fdtable_for_cage(arg1cage, child_cage_id);
-            helpers::clone_cage_routes(arg1cage, child_cage_id);
-        } else {
-            fdtables::init_empty_cage(child_cage_id);
-            for fd in 0..3u64 {
-                let _ = fdtables::get_specific_virtual_fd(child_cage_id, fd, 0, fd, false, 0);
-            }
-        }
+        // Route cloning only — fdtables copy is handled by the lifecycle
+        // fork_handler to avoid double-init when inner grates also handle fork.
+        helpers::clone_cage_routes(arg1cage, child_cage_id);
 
         register_lifecycle_handlers(child_cage_id);
     }


### PR DESCRIPTION
- Move fdtables copy from ns_clone_handler to lifecycle fork_handler to avoid double-init when inner grates also handle fork via preexec
- Always copy fdtables on fork (not just for clamped parents) so child cages have entries for inner grates to track fds
- Remove check_cage_exists from ns_clone_handler
- ns_clone_handler now only does route cloning + lifecycle registration