### PR TITLE
Fix getcwd handler: return byte count, not buffer pointer

### DIFF
--- a/rust-grates/chroot-grate/src/main.rs
+++ b/rust-grates/chroot-grate/src/main.rs
@@ -540,7 +540,7 @@ extern "C" fn getcwd_handler(
         buf.len() as u64,
         0,
     ) {
-        Ok(_) => buf_ptr as i32,
+        Ok(_) => buf.len() as i32,
         Err(_) => -14, // EFAULT
     }
 }


### PR DESCRIPTION
The glibc __getcwd wrapper checks ret < 0 for error. Returning buf_ptr as i32 could be negative if the address is above 2GB, causing getcwd to falsely report failure. Return buf.len() (bytes written including null terminator) instead, matching the RawPOSIX getcwd_syscall convention.