### PR TITLE
Fix grate-rs exit code: decode raw waitpid status with WEXITSTATUS

### DIFF
--- a/lib/grate-rs/src/lib.rs
+++ b/lib/grate-rs/src/lib.rs
@@ -375,7 +375,7 @@ impl GrateBuilder {
     /// - Must always be called from the parent grate.
     fn run_teardown(callback: Option<GrateTeardownCallback>, result: Result<i32, GrateError>) -> ! {
         let exit_code = match &result {
-            Ok(status) => *status,
+            Ok(status) => (*status >> 8) & 0xff, // WEXITSTATUS
             Err(_) => 1,
         };
         match callback {


### PR DESCRIPTION
run_teardown was passing the raw waitpid status (e.g., 256 for exit code 1) to clean_exit. Since exit() truncates to the low 8 bits, 256 & 0xff = 0, so grates always appeared to exit successfully.

Apply WEXITSTATUS decoding ((status >> 8) & 0xff) so the cage's actual exit code propagates through the grate to the caller.