### PR TITLE
Make IPC grate a full fd-translation layer

### DIFF
--- a/lib/grate-rs/src/constants/syscall_numbers.rs
+++ b/lib/grate-rs/src/constants/syscall_numbers.rs
@@ -1,9 +1,17 @@
+//! Linux x86_64 syscall numbers, kept in sync with
+//! `lind-wasm/src/sysdefs/src/constants/syscall_const.rs`,
+//! `glibc/lind_syscall_num.h`, and the RawPOSIX dispatcher.
+//!
+//! Source of truth: Linux x86_64 syscall table
+//!   https://github.com/torvalds/linux/blob/v6.16-rc1/arch/x86/entry/syscalls/syscall_64.tbl
+
 pub const SYS_READ: u64 = 0;
 pub const SYS_WRITE: u64 = 1;
 pub const SYS_OPEN: u64 = 2;
 pub const SYS_CLOSE: u64 = 3;
-pub const SYS_XSTAT: u64 = 4;
-pub const SYS_FXSTAT: u64 = 5;
+pub const SYS_STAT: u64 = 4;
+pub const SYS_FSTAT: u64 = 5;
+pub const SYS_LSTAT: u64 = 6;
 pub const SYS_POLL: u64 = 7;
 pub const SYS_LSEEK: u64 = 8;
 pub const SYS_MMAP: u64 = 9;
@@ -29,7 +37,7 @@ pub const SYS_SHMCTL: u64 = 31;
 pub const SYS_DUP: u64 = 32;
 pub const SYS_DUP2: u64 = 33;
 
-pub const SYS_NANOSLEEP_TIME64: u64 = 35;
+pub const SYS_NANOSLEEP: u64 = 35;
 pub const SYS_SETITIMER: u64 = 38;
 pub const SYS_GETPID: u64 = 39;
 
@@ -74,6 +82,7 @@ pub const SYS_RMDIR: u64 = 84;
 
 pub const SYS_LINK: u64 = 86;
 pub const SYS_UNLINK: u64 = 87;
+pub const SYS_SYMLINK: u64 = 88;
 pub const SYS_READLINK: u64 = 89;
 pub const SYS_CHMOD: u64 = 90;
 pub const SYS_FCHMOD: u64 = 91;
@@ -83,6 +92,7 @@ pub const SYS_GETGID: u64 = 104;
 pub const SYS_GETEUID: u64 = 107;
 pub const SYS_GETEGID: u64 = 108;
 pub const SYS_GETPPID: u64 = 110;
+pub const SYS_GETPGID: u64 = 121;
 pub const SYS_MKNOD: u64 = 133;
 pub const SYS_STATFS: u64 = 137;
 pub const SYS_FSTATFS: u64 = 138;
@@ -91,15 +101,31 @@ pub const SYS_GETHOSTNAME: u64 = 170;
 pub const SYS_FUTEX: u64 = 202;
 pub const SYS_EPOLL_CREATE: u64 = 213;
 pub const SYS_CLOCK_GETTIME: u64 = 228;
+pub const SYS_EXIT_GROUP: u64 = 231;
 pub const SYS_EPOLL_WAIT: u64 = 232;
 pub const SYS_EPOLL_CTL: u64 = 233;
+pub const SYS_OPENAT: u64 = 257;
 pub const SYS_UNLINKAT: u64 = 263;
+pub const SYS_SYMLINKAT: u64 = 266;
 pub const SYS_READLINKAT: u64 = 267;
+pub const SYS_PPOLL: u64 = 271;
 pub const SYS_SYNC_FILE_RANGE: u64 = 277;
+pub const SYS_ACCEPT4: u64 = 288;
 pub const SYS_EPOLL_CREATE1: u64 = 291;
 pub const SYS_DUP3: u64 = 292;
 pub const SYS_PIPE2: u64 = 293;
+pub const SYS_PREADV: u64 = 295;
+pub const SYS_PWRITEV: u64 = 296;
+pub const SYS_PRLIMIT64: u64 = 302;
 pub const SYS_GETRANDOM: u64 = 318;
+
+// --- Backwards-compat aliases ---
+//
+// Older grates referenced SYS_XSTAT / SYS_FXSTAT / SYS_NANOSLEEP_TIME64.
+// Keep these as aliases so existing code keeps compiling.
+pub const SYS_XSTAT: u64 = SYS_STAT;
+pub const SYS_FXSTAT: u64 = SYS_FSTAT;
+pub const SYS_NANOSLEEP_TIME64: u64 = SYS_NANOSLEEP;
 
 /* Lind-specific syscalls (not part of the Linux syscall table) */
 pub const SYS_REGISTER_HANDLER: u64 = 1001;

--- a/lib/grate-rs/src/lib.rs
+++ b/lib/grate-rs/src/lib.rs
@@ -259,10 +259,20 @@ pub fn getcageid() -> u64 {
 ///
 /// In Lind, `arg1` of SYS_CLONE is a pointer to `struct clone_args` in the
 /// calling cage's memory. The `flags` field is the first u64 in the struct.
-/// If `CLONE_VM` (0x100) is set, it's a thread; otherwise it's a process fork.
 ///
-/// Grates should only copy fdtables on process forks, not thread clones
-/// (threads share the parent's fd table).
+/// We check `CLONE_THREAD` rather than `CLONE_VM` because `posix_spawn`
+/// (used by libc `popen`, `system`, etc.) issues
+/// `clone(CLONE_VM | CLONE_VFORK | SIGCHLD)` — vfork-style — which sets
+/// `CLONE_VM` but is NOT a thread.  Treating it as a thread skips the
+/// per-cage state setup grates need to do for the spawned process,
+/// breaking pipes/fdtables for popen children.
+///
+/// Real threads (pthread_create) set `CLONE_THREAD`; vfork-style spawns
+/// do not.  `CLONE_FILES` would be an equivalent check (threads share
+/// the fd table, vfork-spawns don't).
+///
+/// Grates should only skip per-cage state copy on actual thread clones,
+/// not on vfork-style process spawns.
 pub fn is_thread_clone(clone_args_ptr: u64, clone_args_cage: u64) -> bool {
     let grate_cage = getcageid();
     let mut flags: u64 = 0;
@@ -276,7 +286,7 @@ pub fn is_thread_clone(clone_args_ptr: u64, clone_args_cage: u64) -> bool {
         8,
         0,
     );
-    (flags & constants::process::CLONE_VM) != 0
+    (flags & constants::process::CLONE_THREAD) != 0
 }
 
 /// Dispatch function required by 3i to invoke registered syscall handlers.

--- a/rust-grates/ipc-grate/src/handlers.rs
+++ b/rust-grates/ipc-grate/src/handlers.rs
@@ -1,12 +1,186 @@
 //! Syscall handlers for the IPC grate.
 
 use grate_rs::constants::*;
-use grate_rs::{copy_data_between_cages, getcageid, is_thread_clone, make_threei_call};
+use grate_rs::{copy_data_between_cages, copy_handler_table_to_cage, getcageid, is_thread_clone};
 
 use crate::helpers::forward_syscall;
 use crate::ipc::*;
 use crate::pipe;
 use crate::socket;
+
+/// fdkind value for non-IPC fds tracked in fdtables.  `underfd` for these
+/// entries is the runtime's (RawPOSIX's) virt fd — it is NOT identical to
+/// the grate's virt fd, since the grate and the runtime each maintain
+/// their own fdtables instance (wasm linear memory vs host).  We translate
+/// grate-vfd → runtime-vfd via `translate_to_underfd` whenever forwarding
+/// a syscall to RawPOSIX.
+const FDKIND_KERNEL: u32 = 0;
+
+/// EBADF, EMFILE in negative-errno form.
+const EBADF_NEG: i32 = -9;
+const EMFILE_NEG: i32 = -24;
+
+/// AT_FDCWD is the special "current working directory" sentinel for the
+/// *at family of syscalls; it must NOT be translated.
+const AT_FDCWD: i64 = -100;
+
+/// Translate a grate virt fd to the runtime's virt fd (the underfd).
+/// Returns None if the fd doesn't exist in our fdtable.
+fn translate_to_underfd(cage: u64, fd: u64) -> Option<u64> {
+    fdtables::translate_virtual_fd(cage, fd).ok().map(|e| e.underfd)
+}
+
+/// Translate a possibly-AT_FDCWD dirfd; AT_FDCWD passes through unchanged.
+fn translate_dirfd(cage: u64, fd: u64) -> Option<u64> {
+    if (fd as i64) == AT_FDCWD {
+        return Some(fd);
+    }
+    translate_to_underfd(cage, fd)
+}
+
+/// Forward a syscall whose first argument is an fd, translating that fd
+/// to its runtime underfd before forwarding.  Returns -EBADF if the fd
+/// isn't tracked in our grate fdtable.
+fn forward_with_fd1(syscall: u64, cage: u64, args: [u64; 6], arg_cages: [u64; 6]) -> i32 {
+    let under = match translate_to_underfd(cage, args[0]) {
+        Some(u) => u,
+        None => return EBADF_NEG,
+    };
+    let mut t = args;
+    t[0] = under;
+    forward_syscall(syscall, cage, &t, &arg_cages)
+}
+
+/// Forward a syscall whose first argument is a dirfd (may be AT_FDCWD).
+fn forward_with_dirfd1(syscall: u64, cage: u64, args: [u64; 6], arg_cages: [u64; 6]) -> i32 {
+    let under = match translate_dirfd(cage, args[0]) {
+        Some(u) => u,
+        None => return EBADF_NEG,
+    };
+    let mut t = args;
+    t[0] = under;
+    forward_syscall(syscall, cage, &t, &arg_cages)
+}
+
+/// Register a runtime-allocated virt fd in the grate's fdtable as a
+/// FDKIND_KERNEL entry, returning a fresh grate virt fd that maps to it.
+/// On allocation failure, close the runtime fd and return -EMFILE.
+fn register_kernel_fd(cage: u64, runtime_vfd: i32, cloexec: bool, perfdinfo: u64) -> i32 {
+    match fdtables::get_unused_virtual_fd(
+        cage, FDKIND_KERNEL, runtime_vfd as u64, cloexec, perfdinfo,
+    ) {
+        Ok(grate_vfd) => grate_vfd as i32,
+        Err(_) => {
+            forward_syscall(
+                SYS_CLOSE, cage,
+                &[runtime_vfd as u64, 0, 0, 0, 0, 0],
+                &[cage, 0, 0, 0, 0, 0],
+            );
+            EMFILE_NEG
+        }
+    }
+}
+
+/// poll(2) event bits we care about.
+const POLLIN: i16   = 0x0001;
+const POLLPRI: i16  = 0x0002;
+const POLLOUT: i16  = 0x0004;
+const POLLERR: i16  = 0x0008;
+const POLLHUP: i16  = 0x0010;
+const POLLNVAL: i16 = 0x0020;
+
+/// Layout of `struct pollfd` (POSIX): 4-byte fd, 2-byte events, 2-byte revents.
+#[repr(C)]
+#[derive(Copy, Clone, Default)]
+struct PollFd {
+    fd: i32,
+    events: i16,
+    revents: i16,
+}
+
+/// fdtables-level close handler for IPC_PIPE entries.  Called whenever
+/// fdtables decrements an IPC_PIPE entry's refcount — including on
+/// `close_virtualfd`, `empty_fds_for_exec`, and `remove_cage_from_fdtable`
+/// (cage exit).  This is the single source of truth for pipe-object
+/// refcount management, so we don't have to plumb decrements through
+/// every code path that might remove an entry.
+pub fn ipc_pipe_close_handler(entry: fdtables::FDTableEntry, _count: u64) -> Result<(), i32> {
+    if let Some(pipe_arc) = with_ipc(|s| s.get_pipe(entry.underfd)) {
+        let flags = entry.perfdinfo as i32;
+        if is_read_end(flags) {
+            pipe_arc.decr_read_ref();
+        } else {
+            pipe_arc.decr_write_ref();
+        }
+    }
+    Ok(())
+}
+
+/// exit (syscall 60) / exit_group (syscall 231).
+///
+/// RawPOSIX's exit path calls `fdtables::remove_cage_from_fdtable` on
+/// its own fdtables instance, but our IPC grate has its own separate
+/// instance.  Without intercepting exit, our fdtables for the exiting
+/// cage stays populated with stale IPC entries — pipe refcounts never
+/// decrement on process exit, so EOF never fires when a popen child
+/// exits without explicitly closing its pipe end.
+///
+/// We mirror RawPOSIX's behavior: remove the cage from OUR fdtables
+/// (which fires close handlers and decrements pipe/socket refs), then
+/// forward exit to the runtime.
+pub extern "C" fn exit_handler(
+    _cageid: u64,
+    arg1: u64, arg1cage: u64,
+    arg2: u64, arg2cage: u64,
+    arg3: u64, arg3cage: u64,
+    arg4: u64, arg4cage: u64,
+    arg5: u64, arg5cage: u64,
+    arg6: u64, arg6cage: u64,
+) -> i32 {
+    let cage_id = arg1cage;
+
+    if fdtables::check_cage_exists(cage_id) {
+        fdtables::remove_cage_from_fdtable(cage_id);
+    }
+
+    let args = [arg1, arg2, arg3, arg4, arg5, arg6];
+    let arg_cages = [arg1cage, arg2cage, arg3cage, arg4cage, arg5cage, arg6cage];
+    forward_syscall(SYS_EXIT, cage_id, &args, &arg_cages)
+}
+
+/// exit_group (syscall 231): same cleanup as exit_handler but forwards
+/// SYS_EXIT_GROUP.
+pub extern "C" fn exit_group_handler(
+    _cageid: u64,
+    arg1: u64, arg1cage: u64,
+    arg2: u64, arg2cage: u64,
+    arg3: u64, arg3cage: u64,
+    arg4: u64, arg4cage: u64,
+    arg5: u64, arg5cage: u64,
+    arg6: u64, arg6cage: u64,
+) -> i32 {
+    let cage_id = arg1cage;
+
+    if fdtables::check_cage_exists(cage_id) {
+        fdtables::remove_cage_from_fdtable(cage_id);
+    }
+
+    let args = [arg1, arg2, arg3, arg4, arg5, arg6];
+    let arg_cages = [arg1cage, arg2cage, arg3cage, arg4cage, arg5cage, arg6cage];
+    forward_syscall(SYS_EXIT_GROUP, cage_id, &args, &arg_cages)
+}
+
+/// fdtables-level close handler for IPC_SOCKET entries.
+pub fn ipc_socket_close_handler(entry: fdtables::FDTableEntry, _count: u64) -> Result<(), i32> {
+    with_ipc(|s| {
+        if let Some(sock) = s.sockets.get(entry.underfd) {
+            if let Some(ref sp) = sock.sendpipe { sp.decr_write_ref(); }
+            if let Some(ref rp) = sock.recvpipe { rp.decr_read_ref(); }
+        }
+    });
+    Ok(())
+}
+
 
 /// pipe (syscall 22): create a pipe pair.
 ///
@@ -94,7 +268,7 @@ pub extern "C" fn read_handler(
     // Check if this fd is a pipe or socket we own.
     let info = lookup_ipc_fd(cage_id, fd);
     if info.is_none() {
-        return forward_syscall(SYS_READ, cage_id, &args, &arg_cages);
+        return forward_with_fd1(SYS_READ, cage_id, args, arg_cages);
     }
 
     let (underfd, fdkind, flags) = info.unwrap();
@@ -154,7 +328,7 @@ pub extern "C" fn write_handler(
 
     let info = lookup_ipc_fd(cage_id, fd);
     if info.is_none() {
-        return forward_syscall(SYS_WRITE, cage_id, &args, &arg_cages);
+        return forward_with_fd1(SYS_WRITE, cage_id, args, arg_cages);
     }
 
     let (underfd, fdkind, flags) = info.unwrap();
@@ -189,7 +363,430 @@ pub extern "C" fn write_handler(
         count as u64, 0,
     );
 
-    pipe.write(&buf, count, nonblocking)
+    let ret = pipe.write(&buf, count, nonblocking);
+    ret
+}
+
+/// Compute the revents bits for an IPC fd given the requested events.
+/// Reads the pipe state directly via has_data / write_refs / read_refs.
+fn ipc_pipe_poll_state(underfd: u64, fdkind: u32, flags: i32, requested: i16) -> i16 {
+    let mut revents: i16 = 0;
+    let pipe_arc = match fdkind {
+        IPC_PIPE => with_ipc(|s| s.get_pipe(underfd)),
+        socket::IPC_SOCKET => with_ipc(|s| {
+            // For socket reads → recvpipe; for writes → sendpipe.
+            // We'll fetch both and pick based on the requested events.
+            let _ = s; // placate unused if needed
+            s.sockets.get(underfd).and_then(|sock| {
+                if (requested & POLLIN) != 0 {
+                    sock.recvpipe.clone()
+                } else if (requested & POLLOUT) != 0 {
+                    sock.sendpipe.clone()
+                } else {
+                    None
+                }
+            })
+        }),
+        _ => return POLLNVAL,
+    };
+
+    let pipe = match pipe_arc {
+        Some(p) => p,
+        None => return POLLNVAL,
+    };
+
+    // For pipes, check direction matches the request.
+    let is_reader = match fdkind {
+        IPC_PIPE => is_read_end(flags),
+        socket::IPC_SOCKET => (requested & POLLIN) != 0,
+        _ => return POLLNVAL,
+    };
+
+    if (requested & POLLIN) != 0 && is_reader {
+        if pipe.has_data() {
+            revents |= POLLIN;
+        } else if pipe.write_refs.load(std::sync::atomic::Ordering::Acquire) == 0 {
+            // No writers — peer hung up, EOF.  POSIX requires POLLHUP.
+            revents |= POLLHUP;
+        }
+    }
+    if (requested & POLLOUT) != 0 && !is_reader {
+        if pipe.has_space() {
+            revents |= POLLOUT;
+        } else if pipe.read_refs.load(std::sync::atomic::Ordering::Acquire) == 0 {
+            revents |= POLLERR;
+        }
+    }
+
+    revents
+}
+
+/// poll (syscall 7): handle IPC fds locally; mark them negative so the
+/// kernel ignores them when we forward, then merge our IPC revents
+/// back in.  Per poll(2) "if fd is less than 0, then events shall be
+/// ignored, and revents shall be set to 0 in that entry."
+pub extern "C" fn poll_handler(
+    _cageid: u64,
+    arg1: u64, arg1cage: u64,    // pollfd *fds
+    arg2: u64, arg2cage: u64,    // nfds
+    arg3: u64, arg3cage: u64,    // timeout (ms)
+    arg4: u64, arg4cage: u64,
+    arg5: u64, arg5cage: u64,
+    arg6: u64, arg6cage: u64,
+) -> i32 {
+    let cage_id = arg1cage;
+    let nfds = arg2 as usize;
+    let this_cage = getcageid();
+
+    // Empty / null poll: just forward (kernel handles it).
+    if nfds == 0 || arg1 == 0 {
+        let args = [arg1, arg2, arg3, arg4, arg5, arg6];
+        let arg_cages = [arg1cage, arg2cage, arg3cage, arg4cage, arg5cage, arg6cage];
+        return forward_syscall(SYS_POLL, cage_id, &args, &arg_cages);
+    }
+
+    // Read pollfd[] from the cage into a local buffer.
+    let mut pollfds = vec![PollFd::default(); nfds];
+    let bytes = (nfds * core::mem::size_of::<PollFd>()) as u64;
+    let _ = copy_data_between_cages(
+        this_cage, arg1cage,
+        arg1, arg1cage,
+        pollfds.as_mut_ptr() as u64, this_cage,
+        bytes, 0,
+    );
+
+    // First pass: classify each entry.  For IPC entries, compute revents
+    // immediately and remember so we can replace negative fd back to
+    // positive for the result.  Save the original fd values so we can
+    // restore them in the result.
+    let mut original_fds: Vec<i32> = pollfds.iter().map(|p| p.fd).collect();
+    let mut ipc_revents: Vec<i16> = vec![0; nfds];
+    let mut ipc_indices: Vec<usize> = Vec::new();
+    let mut total_ready: i32 = 0;
+
+    for (i, pfd) in pollfds.iter_mut().enumerate() {
+        if pfd.fd < 0 {
+            pfd.revents = 0;
+            continue;
+        }
+        if let Some((underfd, fdkind, flags)) = lookup_ipc_fd(cage_id, pfd.fd as u64) {
+            let revents = ipc_pipe_poll_state(underfd, fdkind, flags, pfd.events);
+            ipc_revents[i] = revents;
+            if revents != 0 {
+                total_ready += 1;
+            }
+            ipc_indices.push(i);
+            // Mark negative so the kernel ignores this entry on forward.
+            pfd.fd = -1;
+        } else {
+            // Non-IPC fd: translate grate vfd → runtime vfd before forwarding.
+            // The original grate vfd is preserved in `original_fds` and
+            // restored after the kernel returns.
+            match translate_to_underfd(cage_id, pfd.fd as u64) {
+                Some(u) => pfd.fd = u as i32,
+                None => pfd.fd = -1, // unknown — make kernel ignore it
+            }
+        }
+    }
+
+    // If the only non-trivial fds were IPC (no kernel fds to wait on)
+    // AND any of them are ready, return immediately.  Otherwise we'd
+    // need the kernel to wait on the timeout — we still forward in
+    // that case so the caller's timeout is honored.
+    let has_kernel_fd = pollfds.iter().any(|p| p.fd >= 0);
+
+    if has_kernel_fd || total_ready == 0 {
+        // Adjust timeout: if we already have IPC entries ready, do a
+        // non-blocking kernel check (timeout=0) so we return promptly.
+        let kernel_timeout = if total_ready > 0 { 0i32 } else { arg3 as i32 };
+
+        // Write the modified pollfd[] back to the cage so the kernel
+        // can read it, then forward.
+        let _ = copy_data_between_cages(
+            this_cage, arg1cage,
+            pollfds.as_ptr() as u64, this_cage,
+            arg1, arg1cage,
+            bytes, 0,
+        );
+        let args = [arg1, arg2, kernel_timeout as u64, arg4, arg5, arg6];
+        let arg_cages = [arg1cage, arg2cage, arg3cage, arg4cage, arg5cage, arg6cage];
+        let kernel_ret = forward_syscall(SYS_POLL, cage_id, &args, &arg_cages);
+        if kernel_ret < 0 {
+            return kernel_ret;
+        }
+        total_ready += kernel_ret;
+
+        // Read back the cage's modified pollfd[] (kernel filled in
+        // revents for the kernel fds; IPC fds have fd=-1 so revents=0).
+        let _ = copy_data_between_cages(
+            this_cage, arg1cage,
+            arg1, arg1cage,
+            pollfds.as_mut_ptr() as u64, this_cage,
+            bytes, 0,
+        );
+    }
+
+    // Restore original fd values for ALL entries (kernel saw runtime vfds
+    // for kernel-backed entries; user expects their original grate vfds).
+    // Then overlay our IPC-computed revents on the IPC entries.
+    for i in 0..nfds {
+        pollfds[i].fd = original_fds[i];
+    }
+    for i in &ipc_indices {
+        pollfds[*i].revents = ipc_revents[*i];
+    }
+
+    // Write final pollfd[] back to the cage.
+    let _ = copy_data_between_cages(
+        this_cage, arg1cage,
+        pollfds.as_ptr() as u64, this_cage,
+        arg1, arg1cage,
+        bytes, 0,
+    );
+
+    total_ready
+}
+
+/// fd_set is 1024 bits.  Under WASM32, __NFDBITS == 32, so the
+/// underlying array is 32 × u32 = 128 bytes.
+const FD_SETSIZE: usize = 1024;
+const FD_SET_WORDS: usize = FD_SETSIZE / 32;
+const FD_SET_BYTES: usize = FD_SET_WORDS * 4;
+
+#[inline] fn fd_isset(fd: usize, set: &[u32; FD_SET_WORDS]) -> bool {
+    fd < FD_SETSIZE && (set[fd >> 5] & (1u32 << (fd & 31))) != 0
+}
+#[inline] fn fd_set_bit(fd: usize, set: &mut [u32; FD_SET_WORDS]) {
+    if fd < FD_SETSIZE { set[fd >> 5] |= 1u32 << (fd & 31); }
+}
+#[inline] fn fd_clr_bit(fd: usize, set: &mut [u32; FD_SET_WORDS]) {
+    if fd < FD_SETSIZE { set[fd >> 5] &= !(1u32 << (fd & 31)); }
+}
+
+/// select (syscall 23): handle IPC fds locally, forward kernel fds.
+///
+/// Same shape as poll_handler: classify each fd in the bitmasks; for
+/// IPC entries, compute readiness directly from pipe state; clear the
+/// bit before forwarding so the kernel doesn't see it; after the
+/// kernel returns, merge our IPC bits back in.
+pub extern "C" fn select_handler(
+    _cageid: u64,
+    arg1: u64, arg1cage: u64,    // nfds
+    arg2: u64, _arg2cage: u64,   // readfds
+    arg3: u64, _arg3cage: u64,   // writefds
+    arg4: u64, _arg4cage: u64,   // exceptfds
+    arg5: u64, arg5cage: u64,    // timeout
+    arg6: u64, arg6cage: u64,
+) -> i32 {
+    let cage_id = arg1cage;
+    let nfds = arg1 as usize;
+    let this_cage = getcageid();
+
+    if nfds == 0 || nfds > FD_SETSIZE {
+        let args = [arg1, arg2, arg3, arg4, arg5, arg6];
+        let arg_cages = [arg1cage, _arg2cage, _arg3cage, _arg4cage, arg5cage, arg6cage];
+        return forward_syscall(SYS_SELECT, cage_id, &args, &arg_cages);
+    }
+
+    // Read each fd_set (if non-null) into local buffers.  Track which
+    // sets are present so we can write only those back later.
+    let mut read_set:   [u32; FD_SET_WORDS] = [0; FD_SET_WORDS];
+    let mut write_set:  [u32; FD_SET_WORDS] = [0; FD_SET_WORDS];
+    let mut except_set: [u32; FD_SET_WORDS] = [0; FD_SET_WORDS];
+    let have_r = arg2 != 0;
+    let have_w = arg3 != 0;
+    let have_e = arg4 != 0;
+
+    if have_r {
+        let _ = copy_data_between_cages(
+            this_cage, arg1cage,
+            arg2, arg1cage,
+            read_set.as_mut_ptr() as u64, this_cage,
+            FD_SET_BYTES as u64, 0,
+        );
+    }
+    if have_w {
+        let _ = copy_data_between_cages(
+            this_cage, arg1cage,
+            arg3, arg1cage,
+            write_set.as_mut_ptr() as u64, this_cage,
+            FD_SET_BYTES as u64, 0,
+        );
+    }
+    if have_e {
+        let _ = copy_data_between_cages(
+            this_cage, arg1cage,
+            arg4, arg1cage,
+            except_set.as_mut_ptr() as u64, this_cage,
+            FD_SET_BYTES as u64, 0,
+        );
+    }
+
+    // Build kernel-side sets (containing runtime vfds) and a reverse
+    // map (runtime_vfd → grate_vfd) so we can reconstruct the user-visible
+    // result sets after the kernel returns.  IPC fds are handled locally
+    // and never forwarded.
+    let mut k_read:   [u32; FD_SET_WORDS] = [0; FD_SET_WORDS];
+    let mut k_write:  [u32; FD_SET_WORDS] = [0; FD_SET_WORDS];
+    let mut k_except: [u32; FD_SET_WORDS] = [0; FD_SET_WORDS];
+
+    let mut ipc_read:   [u32; FD_SET_WORDS] = [0; FD_SET_WORDS];
+    let mut ipc_write:  [u32; FD_SET_WORDS] = [0; FD_SET_WORDS];
+    let mut ipc_except: [u32; FD_SET_WORDS] = [0; FD_SET_WORDS];
+    let mut ipc_ready: i32 = 0;
+
+    // Reverse map: runtime_vfd → Option<grate_vfd>.  Sized to FD_SETSIZE
+    // since runtime vfds are also bounded by the same limit.
+    let mut rev_map: Vec<Option<usize>> = vec![None; FD_SETSIZE];
+    let mut max_under: usize = 0;
+
+    for fd in 0..nfds {
+        let want_r = have_r && fd_isset(fd, &read_set);
+        let want_w = have_w && fd_isset(fd, &write_set);
+        let want_e = have_e && fd_isset(fd, &except_set);
+        if !want_r && !want_w && !want_e { continue; }
+
+        if let Some((underfd, fdkind, flags)) = lookup_ipc_fd(cage_id, fd as u64) {
+            let mut requested_events: i16 = 0;
+            if want_r { requested_events |= POLLIN; }
+            if want_w { requested_events |= POLLOUT; }
+            let revents = ipc_pipe_poll_state(underfd, fdkind, flags, requested_events);
+
+            if want_r && (revents & (POLLIN | POLLHUP)) != 0 {
+                fd_set_bit(fd, &mut ipc_read);
+                ipc_ready += 1;
+            }
+            if want_w && (revents & (POLLOUT | POLLERR)) != 0 {
+                fd_set_bit(fd, &mut ipc_write);
+                ipc_ready += 1;
+            }
+            if want_e && (revents & POLLERR) != 0 {
+                fd_set_bit(fd, &mut ipc_except);
+                ipc_ready += 1;
+            }
+            continue;
+        }
+
+        // Non-IPC: translate to runtime vfd and place in kernel-side sets.
+        let under = match translate_to_underfd(cage_id, fd as u64) {
+            Some(u) => u as usize,
+            None => continue,  // unknown fd — drop it
+        };
+        if under < FD_SETSIZE {
+            rev_map[under] = Some(fd);
+            if under > max_under { max_under = under; }
+            if want_r { fd_set_bit(under, &mut k_read); }
+            if want_w { fd_set_bit(under, &mut k_write); }
+            if want_e { fd_set_bit(under, &mut k_except); }
+        }
+    }
+
+    // Write the kernel-side sets to a scratch region in cage memory by
+    // overwriting the original set buffers.  After we collect kernel
+    // results we'll rebuild the grate-side sets and write those back.
+    if have_r {
+        let _ = copy_data_between_cages(
+            this_cage, arg1cage,
+            k_read.as_ptr() as u64, this_cage,
+            arg2, arg1cage,
+            FD_SET_BYTES as u64, 0,
+        );
+    }
+    if have_w {
+        let _ = copy_data_between_cages(
+            this_cage, arg1cage,
+            k_write.as_ptr() as u64, this_cage,
+            arg3, arg1cage,
+            FD_SET_BYTES as u64, 0,
+        );
+    }
+    if have_e {
+        let _ = copy_data_between_cages(
+            this_cage, arg1cage,
+            k_except.as_ptr() as u64, this_cage,
+            arg4, arg1cage,
+            FD_SET_BYTES as u64, 0,
+        );
+    }
+
+    // Forward to kernel with runtime_nfds = max_under + 1 (or original nfds
+    // if no kernel fds remain so kernel still honors the timeout).
+    let runtime_nfds = if max_under > 0 { (max_under + 1) as u64 } else { arg1 };
+    let args = [runtime_nfds, arg2, arg3, arg4, arg5, arg6];
+    let arg_cages = [arg1cage, _arg2cage, _arg3cage, _arg4cage, arg5cage, arg6cage];
+    let kernel_ret = forward_syscall(SYS_SELECT, cage_id, &args, &arg_cages);
+    if kernel_ret < 0 {
+        return kernel_ret;
+    }
+
+    // Read back kernel-modified sets, translate runtime vfds → grate vfds,
+    // OR in our IPC bits, and write the result back.
+    let mut out_r: [u32; FD_SET_WORDS] = [0; FD_SET_WORDS];
+    let mut out_w: [u32; FD_SET_WORDS] = [0; FD_SET_WORDS];
+    let mut out_e: [u32; FD_SET_WORDS] = [0; FD_SET_WORDS];
+
+    if have_r {
+        let _ = copy_data_between_cages(
+            this_cage, arg1cage,
+            arg2, arg1cage,
+            k_read.as_mut_ptr() as u64, this_cage,
+            FD_SET_BYTES as u64, 0,
+        );
+    }
+    if have_w {
+        let _ = copy_data_between_cages(
+            this_cage, arg1cage,
+            arg3, arg1cage,
+            k_write.as_mut_ptr() as u64, this_cage,
+            FD_SET_BYTES as u64, 0,
+        );
+    }
+    if have_e {
+        let _ = copy_data_between_cages(
+            this_cage, arg1cage,
+            arg4, arg1cage,
+            k_except.as_mut_ptr() as u64, this_cage,
+            FD_SET_BYTES as u64, 0,
+        );
+    }
+
+    for under in 0..=max_under {
+        if let Some(grate_fd) = rev_map[under] {
+            if have_r && fd_isset(under, &k_read)   { fd_set_bit(grate_fd, &mut out_r); }
+            if have_w && fd_isset(under, &k_write)  { fd_set_bit(grate_fd, &mut out_w); }
+            if have_e && fd_isset(under, &k_except) { fd_set_bit(grate_fd, &mut out_e); }
+        }
+    }
+
+    if have_r {
+        for i in 0..FD_SET_WORDS { out_r[i] |= ipc_read[i]; }
+        let _ = copy_data_between_cages(
+            this_cage, arg1cage,
+            out_r.as_ptr() as u64, this_cage,
+            arg2, arg1cage,
+            FD_SET_BYTES as u64, 0,
+        );
+    }
+    if have_w {
+        for i in 0..FD_SET_WORDS { out_w[i] |= ipc_write[i]; }
+        let _ = copy_data_between_cages(
+            this_cage, arg1cage,
+            out_w.as_ptr() as u64, this_cage,
+            arg3, arg1cage,
+            FD_SET_BYTES as u64, 0,
+        );
+    }
+    if have_e {
+        for i in 0..FD_SET_WORDS { out_e[i] |= ipc_except[i]; }
+        let _ = copy_data_between_cages(
+            this_cage, arg1cage,
+            out_e.as_ptr() as u64, this_cage,
+            arg4, arg1cage,
+            FD_SET_BYTES as u64, 0,
+        );
+    }
+
+    kernel_ret + ipc_ready
 }
 
 /// close (syscall 3): close a pipe fd or forward.
@@ -212,43 +809,85 @@ pub extern "C" fn close_handler(
 
     let info = lookup_ipc_fd(cage_id, fd);
     if info.is_none() {
-        return forward_syscall(SYS_CLOSE, cage_id, &args, &arg_cages);
-    }
-
-    let (pipe_id, fdkind, flags) = info.unwrap();
-
-    // Decrement the appropriate refcount based on fd type.
-    match fdkind {
-        IPC_PIPE => {
-            if let Some(pipe) = with_ipc(|s| s.get_pipe(pipe_id)) {
-                if is_read_end(flags) {
-                    pipe.decr_read_ref();
-                } else {
-                    pipe.decr_write_ref();
-                }
+        // Non-IPC fd: translate to runtime vfd, forward SYS_CLOSE so
+        // RawPOSIX closes the kernel fd and removes its own entry, then
+        // remove our grate-side entry.
+        match translate_to_underfd(cage_id, fd) {
+            Some(under) => {
+                let mut t = args;
+                t[0] = under;
+                let ret = forward_syscall(SYS_CLOSE, cage_id, &t, &arg_cages);
+                let _ = fdtables::close_virtualfd(cage_id, fd);
+                ret
+            }
+            None => {
+                // Not in our table at all — forward as-is for runtime to error.
+                forward_syscall(SYS_CLOSE, cage_id, &args, &arg_cages)
             }
         }
-        socket::IPC_SOCKET => {
-            // Closing a socket: decrement write refs on sendpipe (triggers
-            // EOF for peer's reads) and read refs on recvpipe.
-            with_ipc(|s| {
-                if let Some(sock) = s.sockets.get(pipe_id) {
-                    if let Some(ref sp) = sock.sendpipe {
-                        sp.decr_write_ref();
-                    }
-                    if let Some(ref rp) = sock.recvpipe {
-                        rp.decr_read_ref();
-                    }
-                }
-            });
-        }
-        _ => {}
+    } else {
+        // IPC pipe/socket: refs decrement via our registered close handler
+        // when close_virtualfd removes the entry.
+        let _ = fdtables::close_virtualfd(cage_id, fd);
+        0
     }
+}
 
-    // Remove the fd from fdtables.
-    let _ = fdtables::close_virtualfd(cage_id, fd);
+/// open (syscall 2): forward to the runtime, then map the runtime virt fd
+/// to a fresh grate virt fd via fdtables.
+///
+/// We allocate a NEW grate vfd (`get_unused_virtual_fd`) so the user-visible
+/// fd never collides with a live IPC pipe/socket entry.  The runtime's vfd
+/// is stored as the underfd; subsequent grate-side syscall handlers translate
+/// grate-vfd → runtime-vfd (underfd) before forwarding.
+pub extern "C" fn open_handler(
+    cageid: u64,
+    arg1: u64, arg1cage: u64,    // path
+    arg2: u64, arg2cage: u64,    // flags
+    arg3: u64, arg3cage: u64,    // mode
+    arg4: u64, arg4cage: u64,
+    arg5: u64, arg5cage: u64,
+    arg6: u64, arg6cage: u64,
+) -> i32 {
+    let cage_id = arg1cage;
+    let flags = arg2 as i32;
+    let args = [arg1, arg2, arg3, arg4, arg5, arg6];
+    let arg_cages = [arg1cage, arg2cage, arg3cage, arg4cage, arg5cage, arg6cage];
 
-    0
+    let runtime_vfd = forward_syscall(SYS_OPEN, cage_id, &args, &arg_cages);
+    if runtime_vfd < 0 {
+        return runtime_vfd;
+    }
+    let cloexec = (flags & O_CLOEXEC) != 0;
+    register_kernel_fd(cage_id, runtime_vfd, cloexec, flags as u64)
+}
+
+/// openat (syscall 257): same as open but with a dirfd that may be AT_FDCWD.
+pub extern "C" fn openat_handler(
+    _cageid: u64,
+    arg1: u64, arg1cage: u64,    // dirfd
+    arg2: u64, arg2cage: u64,    // path
+    arg3: u64, arg3cage: u64,    // flags
+    arg4: u64, arg4cage: u64,    // mode
+    arg5: u64, arg5cage: u64,
+    arg6: u64, arg6cage: u64,
+) -> i32 {
+    let cage_id = arg1cage;
+    let flags = arg3 as i32;
+    let mut args = [arg1, arg2, arg3, arg4, arg5, arg6];
+    let arg_cages = [arg1cage, arg2cage, arg3cage, arg4cage, arg5cage, arg6cage];
+
+    args[0] = match translate_dirfd(cage_id, arg1) {
+        Some(u) => u,
+        None => return EBADF_NEG,
+    };
+
+    let runtime_vfd = forward_syscall(SYS_OPENAT, cage_id, &args, &arg_cages);
+    if runtime_vfd < 0 {
+        return runtime_vfd;
+    }
+    let cloexec = (flags & O_CLOEXEC) != 0;
+    register_kernel_fd(cage_id, runtime_vfd, cloexec, flags as u64)
 }
 
 /// dup (syscall 32): duplicate a pipe fd or forward.
@@ -271,7 +910,19 @@ pub extern "C" fn dup_handler(
 
     let info = lookup_ipc_fd(cage_id, fd);
     if info.is_none() {
-        return forward_syscall(SYS_DUP, cage_id, &args, &arg_cages);
+        // Non-IPC fd: translate to runtime vfd, forward SYS_DUP, register
+        // the new runtime vfd as a fresh grate vfd.
+        let under = match translate_to_underfd(cage_id, fd) {
+            Some(u) => u,
+            None => return EBADF_NEG,
+        };
+        let mut t = args;
+        t[0] = under;
+        let new_runtime_vfd = forward_syscall(SYS_DUP, cage_id, &t, &arg_cages);
+        if new_runtime_vfd < 0 {
+            return new_runtime_vfd;
+        }
+        return register_kernel_fd(cage_id, new_runtime_vfd, false, 0);
     }
 
     let (pipe_id, fdkind, flags) = info.unwrap();
@@ -330,39 +981,55 @@ pub extern "C" fn dup2_handler(
     let args = [arg1, arg2, arg3, arg4, arg5, arg6];
     let arg_cages = [arg1cage, _arg2cage, arg3cage, arg4cage, arg5cage, arg6cage];
 
+    if oldfd == newfd {
+        return newfd as i32;
+    }
+
+    // Helper closure: if newfd currently maps to a runtime fd, close that
+    // runtime fd before we overwrite the grate-side entry.  IPC entries
+    // get refcount-decremented by the registered close handler that
+    // get_specific_virtual_fd fires; FDKIND_KERNEL entries have no close
+    // handler, so we have to forward SYS_CLOSE explicitly.
+    let close_old_runtime_if_kernel = || {
+        if let Ok(old) = fdtables::translate_virtual_fd(cage_id, newfd) {
+            if old.fdkind == FDKIND_KERNEL {
+                forward_syscall(SYS_CLOSE, cage_id,
+                    &[old.underfd, 0, 0, 0, 0, 0],
+                    &[cage_id, 0, 0, 0, 0, 0]);
+            }
+        }
+    };
+
     let info = lookup_ipc_fd(cage_id, oldfd);
     if info.is_none() {
-        return forward_syscall(SYS_DUP2, cage_id, &args, &arg_cages);
+        // FDKIND_KERNEL oldfd: dup at the runtime to get a fresh runtime
+        // vfd, then point grate's newfd at it.
+        let old_under = match translate_to_underfd(cage_id, oldfd) {
+            Some(u) => u,
+            None => return EBADF_NEG,
+        };
+        let new_runtime_vfd = forward_syscall(
+            SYS_DUP, cage_id,
+            &[old_under, 0, 0, 0, 0, 0],
+            &[cage_id, 0, 0, 0, 0, 0],
+        );
+        if new_runtime_vfd < 0 {
+            return new_runtime_vfd;
+        }
+        close_old_runtime_if_kernel();
+        let _ = fdtables::get_specific_virtual_fd(
+            cage_id, newfd, FDKIND_KERNEL, new_runtime_vfd as u64, false, 0,
+        );
+        return newfd as i32;
     }
 
     let (pipe_id, fdkind, flags) = info.unwrap();
 
-    // Close newfd if it's already open (dup2 semantics).
-    // If newfd was a pipe/socket, close_handler would handle its refcounts,
-    // but close_virtualfd doesn't call our handler, so we need to manually
-    // decrement refs if newfd was one of ours.
-    if let Some((new_underfd, new_fdkind, new_flags)) = lookup_ipc_fd(cage_id, newfd) {
-        match new_fdkind {
-            IPC_PIPE => {
-                if let Some(pipe) = with_ipc(|s| s.get_pipe(new_underfd)) {
-                    if is_read_end(new_flags) { pipe.decr_read_ref(); }
-                    else { pipe.decr_write_ref(); }
-                }
-            }
-            socket::IPC_SOCKET => {
-                with_ipc(|s| {
-                    if let Some(sock) = s.sockets.get(new_underfd) {
-                        if let Some(ref sp) = sock.sendpipe { sp.decr_write_ref(); }
-                        if let Some(ref rp) = sock.recvpipe { rp.decr_read_ref(); }
-                    }
-                });
-            }
-            _ => {}
-        }
-    }
-    let _ = fdtables::close_virtualfd(cage_id, newfd);
+    close_old_runtime_if_kernel();
 
-    // Register the new fd at the specific number.
+    // get_specific_virtual_fd implicitly closes the previous entry on
+    // newfd (calls our registered close handler if it was IPC), then
+    // installs the new entry.
     let _ = fdtables::get_specific_virtual_fd(
         cage_id, newfd, fdkind, pipe_id, false, flags as u64,
     );
@@ -425,7 +1092,7 @@ pub extern "C" fn fcntl_handler(
 
     let info = lookup_ipc_fd(cage_id, fd);
     if info.is_none() {
-        return forward_syscall(SYS_FCNTL, cage_id, &args, &arg_cages);
+        return forward_with_fd1(SYS_FCNTL, cage_id, args, arg_cages);
     }
 
     let (_pipe_id, _fdkind, flags) = info.unwrap();
@@ -433,8 +1100,16 @@ pub extern "C" fn fcntl_handler(
     match op {
         F_GETFL => flags,
         F_SETFL => {
-            // Update perfdinfo in fdtables.
-            let _ = fdtables::set_perfdinfo(cage_id, fd, arg3);
+            // F_SETFL changes only the file status flags (O_APPEND,
+            // O_NONBLOCK, O_ASYNC, O_DIRECT, O_NOATIME).  The access
+            // mode (O_RDONLY/O_WRONLY/O_RDWR) is immutable.  We MUST
+            // preserve those bits — they're how we distinguish pipe
+            // read-end from write-end.  Overwriting them with just
+            // arg3 (e.g. O_NONBLOCK alone) makes a write-end look like
+            // a read-end, so writes return EBADF and postgres's
+            // self-pipe wakeup never fires → WaitLatch hangs forever.
+            let new_flags = (flags & O_ACCMODE) | (arg3 as i32 & !O_ACCMODE);
+            let _ = fdtables::set_perfdinfo(cage_id, fd, new_flags as u64);
             0
         }
         F_GETFD => {
@@ -558,10 +1233,41 @@ pub extern "C" fn fork_handler(
             }
         }
 
-        // Now create the child cage in fdtables — this is the signal that
-        // unblocks the child's spin-wait in lookup_ipc_fd.
+        // Snapshot the parent's IPC entries — copy_fdtable_for_cage on
+        // the shared fdtables instance might be a no-op if the child
+        // cage was already created by another grate (RawPOSIX's
+        // fork_syscall does its own copy).  We re-install the IPC
+        // entries explicitly to make sure they're there.
+        let parent_fds = fdtables::return_fdtable_copy(cage_id);
         let _ = fdtables::copy_fdtable_for_cage(cage_id, child_cage_id);
+
+        // Make sure cage exists; if RawPOSIX already populated it, the
+        // copy above was a no-op.  Either way we now overlay our IPC
+        // entries explicitly.
+        if !fdtables::check_cage_exists(child_cage_id) {
+            fdtables::init_empty_cage(child_cage_id);
+        }
+
+        for (fd, entry) in &parent_fds {
+            if entry.fdkind == IPC_PIPE || entry.fdkind == socket::IPC_SOCKET {
+                let _ = fdtables::get_specific_virtual_fd(
+                    child_cage_id,
+                    *fd,
+                    entry.fdkind,
+                    entry.underfd,
+                    entry.should_cloexec,
+                    entry.perfdinfo,
+                );
+            }
+        }
+
+        // Propagate our registered syscall handlers to the new cage so
+        // its read/write/close/etc. continue to flow through us instead
+        // of crashing the runtime with "no handler for cage N syscall M".
+        let grate_cage = getcageid();
+        let _ = copy_handler_table_to_cage(grate_cage, child_cage_id);
     }
+
 
     child_cage_id as i32
 }
@@ -578,22 +1284,37 @@ pub extern "C" fn exec_handler(
 ) -> i32 {
     let cage_id = arg1cage;
 
-    // Close cloexec fds.
+    // Init cage if missing (vfork-spawn path: posix_spawn child execs
+    // before our parent fork_handler can copy_fdtable_for_cage).
+    if !fdtables::check_cage_exists(cage_id) {
+        fdtables::init_empty_cage(cage_id);
+    }
+
+    // Close cloexec fds.  Our registered fdtables close handlers
+    // (ipc_pipe_close_handler / ipc_socket_close_handler) fire from
+    // empty_fds_for_exec's _decrement_fdcount path, so pipe/socket
+    // refcounts get decremented automatically.
     fdtables::empty_fds_for_exec(cage_id);
 
     // Reserve fds 0/1/2 (stdin/stdout/stderr) so that pipe() and socket()
     // never allocate them.  Without this, the first pipe() gets fds 0 and 1,
     // which hijacks stdout — every printf goes into a pipe instead of the
     // console.  fdkind=0 marks these as non-IPC (lookup_ipc_fd ignores them).
+    //
+    // Only reserve if not already occupied — popen() dup2's a pipe onto fd 0
+    // before exec, and we must not overwrite that mapping.
     for fd in 0..3u64 {
-        let _ = fdtables::get_specific_virtual_fd(cage_id, fd, 0, fd, false, 0);
+        if fdtables::translate_virtual_fd(cage_id, fd).is_err() {
+            let _ = fdtables::get_specific_virtual_fd(cage_id, fd, 0, fd, false, 0);
+        }
     }
 
-    forward_syscall(
+    let ret = forward_syscall(
         SYS_EXEC, cage_id,
         &[arg1, arg2, arg3, arg4, arg5, arg6],
         &[arg1cage, arg2cage, arg3cage, arg4cage, arg5cage, arg6cage],
-    )
+    );
+    ret
 }
 
 // =====================================================================
@@ -619,9 +1340,15 @@ pub extern "C" fn socket_handler(
     let args = [arg1, arg2, arg3, arg4, arg5, arg6];
     let arg_cages = [arg1cage, _arg2cage, _arg3cage, arg4cage, arg5cage, arg6cage];
 
-    // Only handle AF_UNIX and AF_INET (for potential loopback).
+    // Only handle AF_UNIX and AF_INET (for potential loopback); everything
+    // else just gets forwarded to the runtime with a fresh grate vfd wrapping
+    // the runtime vfd.
     if domain != socket::AF_UNIX && domain != socket::AF_INET {
-        return forward_syscall(SYS_SOCKET, cage_id, &args, &arg_cages);
+        let runtime_vfd = forward_syscall(SYS_SOCKET, cage_id, &args, &arg_cages);
+        if runtime_vfd < 0 {
+            return runtime_vfd;
+        }
+        return register_kernel_fd(cage_id, runtime_vfd, false, 0);
     }
 
     if domain == socket::AF_UNIX {
@@ -634,28 +1361,31 @@ pub extern "C" fn socket_handler(
             Ok(fd) => fd as i32,
             Err(_) => {
                 with_ipc(|s| s.sockets.remove(socket_id));
-                -24 // EMFILE
+                EMFILE_NEG
             }
         };
     }
 
-    // AF_INET: forward to kernel to get a real fd. We don't know yet
+    // AF_INET: forward to runtime to get a real fd. We don't know yet
     // whether this will be loopback (127.0.0.1) or remote. We'll find
-    // out at bind/connect time. If loopback, we close the kernel fd
-    // and take over with pipes. If not, we drop our tracking.
-    let kernel_fd = forward_syscall(SYS_SOCKET, cage_id, &args, &arg_cages);
-    if kernel_fd < 0 {
-        return kernel_fd;
+    // out at bind/connect time. If loopback, we close the runtime fd
+    // and convert our entry to IPC_SOCKET in place at the same grate vfd.
+    let runtime_vfd = forward_syscall(SYS_SOCKET, cage_id, &args, &arg_cages);
+    if runtime_vfd < 0 {
+        return runtime_vfd;
+    }
+    let grate_vfd = register_kernel_fd(cage_id, runtime_vfd, false, 0);
+    if grate_vfd < 0 {
+        return grate_vfd;
     }
 
-    // Create a socket in our registry and track it as pending.
-    let socket_id = with_ipc(|s| {
+    // Create a socket in our registry and track it as pending, keyed by grate vfd.
+    with_ipc(|s| {
         let sid = s.sockets.create_socket(domain, socktype, 0);
-        s.pending_inet.insert((cage_id, kernel_fd as u64), sid);
-        sid
+        s.pending_inet.insert((cage_id, grate_vfd as u64), sid);
     });
 
-    kernel_fd
+    grate_vfd
 }
 
 /// socketpair (syscall 53): create a connected pair of unix sockets.
@@ -736,7 +1466,7 @@ pub extern "C" fn bind_handler(
     // Read the sockaddr from cage memory to determine the address.
     let addrlen = arg3 as usize;
     if addrlen < 2 {
-        return forward_syscall(SYS_BIND, cage_id, &args, &arg_cages);
+        return forward_with_fd1(SYS_BIND, cage_id, args, arg_cages);
     }
     let mut addr_buf = vec![0u8; addrlen];
     let _ = copy_data_between_cages(
@@ -754,6 +1484,30 @@ pub extern "C" fn bind_handler(
             let path_bytes = &addr_buf[2..];
             let len = path_bytes.iter().position(|&b| b == 0).unwrap_or(path_bytes.len());
             let addr_string = String::from_utf8_lossy(&path_bytes[..len]).to_string();
+
+            // Create a placeholder file at the path on the actual
+            // filesystem so subsequent chmod / unlink calls (postgres
+            // does both) succeed.  Our actual socket I/O is in the
+            // userspace pipe registry; this file just satisfies
+            // filesystem-level operations on the bind path.
+            //
+            // The path lives in the cage memory at arg2+2 (sockaddr_un
+            // starts with 2-byte sun_family, then sun_path).
+            const O_WRONLY: u64 = 1;
+            const O_CREAT: u64 = 0o100;
+            const O_TRUNC: u64 = 0o1000;
+            let placeholder_fd = forward_syscall(
+                SYS_OPEN, cage_id,
+                &[arg2 + 2, O_WRONLY | O_CREAT | O_TRUNC, 0o666, 0, 0, 0],
+                &[arg2cage, arg2cage, arg2cage, 0, 0, 0],
+            );
+            if placeholder_fd >= 0 {
+                let _ = forward_syscall(
+                    SYS_CLOSE, cage_id,
+                    &[placeholder_fd as u64, 0, 0, 0, 0, 0],
+                    &[arg1cage, 0, 0, 0, 0, 0],
+                );
+            }
 
             return with_ipc(|s| {
                 if let Some(sock) = s.sockets.get_mut(socket_id) {
@@ -783,13 +1537,16 @@ pub extern "C" fn bind_handler(
             let is_loopback = ip == [127, 0, 0, 1] || ip == [0, 0, 0, 0];
 
             if is_loopback {
-                // Take over: close the kernel fd and register in fdtables.
-                forward_syscall(SYS_CLOSE, cage_id,
-                    &[fd, 0, 0, 0, 0, 0], &[arg1cage, 0, 0, 0, 0, 0]);
+                // Take over: close the runtime fd backing this grate vfd and
+                // overwrite our grate-side entry with IPC_SOCKET.
+                if let Some(under) = translate_to_underfd(cage_id, fd) {
+                    forward_syscall(SYS_CLOSE, cage_id,
+                        &[under, 0, 0, 0, 0, 0], &[cage_id, 0, 0, 0, 0, 0]);
+                }
 
                 let addr_string = format!("127.0.0.1:{}", port);
 
-                // Register in fdtables at the same fd number.
+                // Overwrite grate vfd's FDKIND_KERNEL entry with IPC_SOCKET.
                 let _ = fdtables::get_specific_virtual_fd(
                     cage_id, fd, socket::IPC_SOCKET, socket_id, false, 0,
                 );
@@ -808,13 +1565,13 @@ pub extern "C" fn bind_handler(
                     s.pending_inet.remove(&(cage_id, fd));
                     s.sockets.remove(socket_id);
                 });
-                return forward_syscall(SYS_BIND, cage_id, &args, &arg_cages);
+                return forward_with_fd1(SYS_BIND, cage_id, args, arg_cages);
             }
         }
     }
 
-    // Not ours — forward.
-    forward_syscall(SYS_BIND, cage_id, &args, &arg_cages)
+    // Not ours — forward with translated fd.
+    forward_with_fd1(SYS_BIND, cage_id, args, arg_cages)
 }
 
 /// listen (syscall 50): mark a socket as listening.
@@ -834,7 +1591,7 @@ pub extern "C" fn listen_handler(
 
     let info = lookup_ipc_fd(cage_id, fd);
     if info.is_none() {
-        return forward_syscall(SYS_LISTEN, cage_id, &args, &arg_cages);
+        return forward_with_fd1(SYS_LISTEN, cage_id, args, arg_cages);
     }
 
     let (socket_id, fdkind, _) = info.unwrap();
@@ -876,7 +1633,7 @@ pub extern "C" fn connect_handler(
     // Read the target address from cage memory.
     let addrlen = arg3 as usize;
     if addrlen < 2 {
-        return forward_syscall(SYS_CONNECT, cage_id, &args, &arg_cages);
+        return forward_with_fd1(SYS_CONNECT, cage_id, args, arg_cages);
     }
     let mut addr_buf = vec![0u8; addrlen];
     let _ = copy_data_between_cages(
@@ -891,7 +1648,7 @@ pub extern "C" fn connect_handler(
     // Resolve the socket_id — either from fdtables (AF_UNIX) or pending_inet (AF_INET).
     let socket_id = if let Some((sid, fdkind, _)) = lookup_ipc_fd(cage_id, fd) {
         if fdkind != socket::IPC_SOCKET {
-            return forward_syscall(SYS_CONNECT, cage_id, &args, &arg_cages);
+            return forward_with_fd1(SYS_CONNECT, cage_id, args, arg_cages);
         }
         sid
     } else if let Some(sid) = with_ipc(|s| s.pending_inet.get(&(cage_id, fd)).copied()) {
@@ -905,10 +1662,11 @@ pub extern "C" fn connect_handler(
             let is_loopback = ip == [127, 0, 0, 1] || ip == [0, 0, 0, 0];
 
             if is_loopback {
-                // Take over: close kernel fd, register in fdtables.
-                forward_syscall(SYS_CLOSE, cage_id,
-                    &[fd, 0, 0, 0, 0, 0], &[arg1cage, 0, 0, 0, 0, 0]);
-
+                // Take over: close runtime fd, overwrite grate entry as IPC_SOCKET.
+                if let Some(under) = translate_to_underfd(cage_id, fd) {
+                    forward_syscall(SYS_CLOSE, cage_id,
+                        &[under, 0, 0, 0, 0, 0], &[cage_id, 0, 0, 0, 0, 0]);
+                }
                 let _ = fdtables::get_specific_virtual_fd(
                     cage_id, fd, socket::IPC_SOCKET, sid, false, 0,
                 );
@@ -920,13 +1678,13 @@ pub extern "C" fn connect_handler(
                     s.pending_inet.remove(&(cage_id, fd));
                     s.sockets.remove(sid);
                 });
-                return forward_syscall(SYS_CONNECT, cage_id, &args, &arg_cages);
+                return forward_with_fd1(SYS_CONNECT, cage_id, args, arg_cages);
             }
         } else {
-            return forward_syscall(SYS_CONNECT, cage_id, &args, &arg_cages);
+            return forward_with_fd1(SYS_CONNECT, cage_id, args, arg_cages);
         }
     } else {
-        return forward_syscall(SYS_CONNECT, cage_id, &args, &arg_cages);
+        return forward_with_fd1(SYS_CONNECT, cage_id, args, arg_cages);
     };
 
     // Parse the target address string for our registry.
@@ -999,7 +1757,19 @@ pub extern "C" fn accept_handler(
 
     let info = lookup_ipc_fd(cage_id, fd);
     if info.is_none() {
-        return forward_syscall(SYS_ACCEPT, cage_id, &args, &arg_cages);
+        // Non-IPC accept: translate listening fd to runtime vfd, forward,
+        // register the new runtime vfd as a fresh grate vfd.
+        let under = match translate_to_underfd(cage_id, fd) {
+            Some(u) => u,
+            None => return EBADF_NEG,
+        };
+        let mut t = args;
+        t[0] = under;
+        let new_runtime_vfd = forward_syscall(SYS_ACCEPT, cage_id, &t, &arg_cages);
+        if new_runtime_vfd < 0 {
+            return new_runtime_vfd;
+        }
+        return register_kernel_fd(cage_id, new_runtime_vfd, false, 0);
     }
 
     let (socket_id, fdkind, flags) = info.unwrap();
@@ -1087,7 +1857,7 @@ pub extern "C" fn shutdown_handler(
 
     let info = lookup_ipc_fd(cage_id, fd);
     if info.is_none() {
-        return forward_syscall(SYS_SHUTDOWN, cage_id, &args, &arg_cages);
+        return forward_with_fd1(SYS_SHUTDOWN, cage_id, args, arg_cages);
     }
 
     let (socket_id, fdkind, _) = info.unwrap();
@@ -1125,4 +1895,263 @@ pub extern "C" fn shutdown_handler(
         }
         0
     })
+}
+
+// =====================================================================
+//  Pure-translation handlers
+// =====================================================================
+//
+//  These handlers exist solely to translate the grate-side virt fd in
+//  arg1 (or wherever the fd appears) to the runtime's virt fd before
+//  forwarding to RawPOSIX.  Without these, RawPOSIX would receive a
+//  grate vfd that means nothing in its own fdtable and return EBADF.
+//
+//  All of them are simple "translate fd, forward" wrappers; they don't
+//  inspect the operation itself.
+
+macro_rules! translate_fd1_handler {
+    ($name:ident, $sysno:expr) => {
+        pub extern "C" fn $name(
+            _cageid: u64,
+            arg1: u64, arg1cage: u64,
+            arg2: u64, arg2cage: u64,
+            arg3: u64, arg3cage: u64,
+            arg4: u64, arg4cage: u64,
+            arg5: u64, arg5cage: u64,
+            arg6: u64, arg6cage: u64,
+        ) -> i32 {
+            let cage_id = arg1cage;
+            let args = [arg1, arg2, arg3, arg4, arg5, arg6];
+            let arg_cages = [arg1cage, arg2cage, arg3cage, arg4cage, arg5cage, arg6cage];
+            forward_with_fd1($sysno, cage_id, args, arg_cages)
+        }
+    };
+}
+
+// epoll_ctl (arg1 = epfd, arg2 = op, arg3 = fd) — translate both fds.
+pub extern "C" fn epoll_ctl_handler(
+    _cageid: u64,
+    arg1: u64, arg1cage: u64,    // epfd
+    arg2: u64, arg2cage: u64,    // op
+    arg3: u64, arg3cage: u64,    // fd
+    arg4: u64, arg4cage: u64,    // event
+    arg5: u64, arg5cage: u64,
+    arg6: u64, arg6cage: u64,
+) -> i32 {
+    let cage_id = arg1cage;
+    let mut args = [arg1, arg2, arg3, arg4, arg5, arg6];
+    let arg_cages = [arg1cage, arg2cage, arg3cage, arg4cage, arg5cage, arg6cage];
+    args[0] = match translate_to_underfd(cage_id, arg1) { Some(u) => u, None => return EBADF_NEG };
+    args[2] = match translate_to_underfd(cage_id, arg3) { Some(u) => u, None => return EBADF_NEG };
+    forward_syscall(SYS_EPOLL_CTL, cage_id, &args, &arg_cages)
+}
+
+/// epoll_create / epoll_create1: returns a fresh fd from the runtime —
+/// register it as a fresh grate vfd.
+pub extern "C" fn epoll_create_handler(
+    _cageid: u64,
+    arg1: u64, arg1cage: u64,
+    arg2: u64, arg2cage: u64,
+    arg3: u64, arg3cage: u64,
+    arg4: u64, arg4cage: u64,
+    arg5: u64, arg5cage: u64,
+    arg6: u64, arg6cage: u64,
+) -> i32 {
+    let cage_id = arg1cage;
+    let args = [arg1, arg2, arg3, arg4, arg5, arg6];
+    let arg_cages = [arg1cage, arg2cage, arg3cage, arg4cage, arg5cage, arg6cage];
+    let runtime_vfd = forward_syscall(SYS_EPOLL_CREATE, cage_id, &args, &arg_cages);
+    if runtime_vfd < 0 { return runtime_vfd; }
+    register_kernel_fd(cage_id, runtime_vfd, false, 0)
+}
+
+pub extern "C" fn epoll_create1_handler(
+    _cageid: u64,
+    arg1: u64, arg1cage: u64,    // flags
+    arg2: u64, arg2cage: u64,
+    arg3: u64, arg3cage: u64,
+    arg4: u64, arg4cage: u64,
+    arg5: u64, arg5cage: u64,
+    arg6: u64, arg6cage: u64,
+) -> i32 {
+    let cage_id = arg1cage;
+    let args = [arg1, arg2, arg3, arg4, arg5, arg6];
+    let arg_cages = [arg1cage, arg2cage, arg3cage, arg4cage, arg5cage, arg6cage];
+    let runtime_vfd = forward_syscall(SYS_EPOLL_CREATE1, cage_id, &args, &arg_cages);
+    if runtime_vfd < 0 { return runtime_vfd; }
+    let cloexec = (arg1 as i32 & O_CLOEXEC) != 0;
+    register_kernel_fd(cage_id, runtime_vfd, cloexec, 0)
+}
+
+/// ppoll (syscall 271): same shape as poll but with a timespec timeout
+/// and a sigmask.  Same fd-translation logic as poll_handler.
+pub extern "C" fn ppoll_handler(
+    _cageid: u64,
+    arg1: u64, arg1cage: u64,    // pollfd *fds
+    arg2: u64, arg2cage: u64,    // nfds
+    arg3: u64, arg3cage: u64,    // timeout_ts *
+    arg4: u64, arg4cage: u64,    // sigmask
+    arg5: u64, arg5cage: u64,    // sigsetsize
+    arg6: u64, arg6cage: u64,
+) -> i32 {
+    let cage_id = arg1cage;
+    let nfds = arg2 as usize;
+    let this_cage = getcageid();
+
+    if nfds == 0 || arg1 == 0 {
+        let args = [arg1, arg2, arg3, arg4, arg5, arg6];
+        let arg_cages = [arg1cage, arg2cage, arg3cage, arg4cage, arg5cage, arg6cage];
+        return forward_syscall(SYS_PPOLL, cage_id, &args, &arg_cages);
+    }
+
+    let mut pollfds = vec![PollFd::default(); nfds];
+    let bytes = (nfds * core::mem::size_of::<PollFd>()) as u64;
+    let _ = copy_data_between_cages(
+        this_cage, arg1cage, arg1, arg1cage,
+        pollfds.as_mut_ptr() as u64, this_cage, bytes, 0,
+    );
+
+    let original_fds: Vec<i32> = pollfds.iter().map(|p| p.fd).collect();
+    let mut ipc_revents: Vec<i16> = vec![0; nfds];
+    let mut ipc_indices: Vec<usize> = Vec::new();
+    let mut total_ready: i32 = 0;
+
+    for (i, pfd) in pollfds.iter_mut().enumerate() {
+        if pfd.fd < 0 {
+            pfd.revents = 0;
+            continue;
+        }
+        if let Some((underfd, fdkind, flags)) = lookup_ipc_fd(cage_id, pfd.fd as u64) {
+            let revents = ipc_pipe_poll_state(underfd, fdkind, flags, pfd.events);
+            ipc_revents[i] = revents;
+            if revents != 0 { total_ready += 1; }
+            ipc_indices.push(i);
+            pfd.fd = -1;
+        } else {
+            match translate_to_underfd(cage_id, pfd.fd as u64) {
+                Some(u) => pfd.fd = u as i32,
+                None => pfd.fd = -1,
+            }
+        }
+    }
+
+    let _ = copy_data_between_cages(
+        this_cage, arg1cage,
+        pollfds.as_ptr() as u64, this_cage, arg1, arg1cage, bytes, 0,
+    );
+    let args = [arg1, arg2, arg3, arg4, arg5, arg6];
+    let arg_cages = [arg1cage, arg2cage, arg3cage, arg4cage, arg5cage, arg6cage];
+    let kernel_ret = forward_syscall(SYS_PPOLL, cage_id, &args, &arg_cages);
+    if kernel_ret < 0 && total_ready == 0 { return kernel_ret; }
+    if kernel_ret > 0 { total_ready += kernel_ret; }
+
+    let _ = copy_data_between_cages(
+        this_cage, arg1cage, arg1, arg1cage,
+        pollfds.as_mut_ptr() as u64, this_cage, bytes, 0,
+    );
+    for i in 0..nfds { pollfds[i].fd = original_fds[i]; }
+    for i in &ipc_indices { pollfds[*i].revents = ipc_revents[*i]; }
+    let _ = copy_data_between_cages(
+        this_cage, arg1cage,
+        pollfds.as_ptr() as u64, this_cage, arg1, arg1cage, bytes, 0,
+    );
+
+    total_ready
+}
+
+// File ops with fd in arg1
+translate_fd1_handler!(lseek_handler,            SYS_LSEEK);
+translate_fd1_handler!(epoll_wait_handler,       SYS_EPOLL_WAIT);
+translate_fd1_handler!(ioctl_handler,            SYS_IOCTL);
+translate_fd1_handler!(fstat_handler,            SYS_FSTAT);
+translate_fd1_handler!(fsync_handler,            SYS_FSYNC);
+translate_fd1_handler!(fdatasync_handler,        SYS_FDATASYNC);
+translate_fd1_handler!(ftruncate_handler,        SYS_FTRUNCATE);
+translate_fd1_handler!(getdents_handler,         SYS_GETDENTS);
+translate_fd1_handler!(fstatfs_handler,          SYS_FSTATFS);
+translate_fd1_handler!(fchdir_handler,           SYS_FCHDIR);
+translate_fd1_handler!(fchmod_handler,           SYS_FCHMOD);
+translate_fd1_handler!(flock_handler,            SYS_FLOCK);
+translate_fd1_handler!(pread_handler,            SYS_PREAD);
+translate_fd1_handler!(pwrite_handler,           SYS_PWRITE);
+translate_fd1_handler!(readv_handler,            SYS_READV);
+translate_fd1_handler!(writev_handler,           SYS_WRITEV);
+translate_fd1_handler!(preadv_handler,           SYS_PREADV);
+translate_fd1_handler!(pwritev_handler,          SYS_PWRITEV);
+translate_fd1_handler!(sync_file_range_handler,  SYS_SYNC_FILE_RANGE);
+
+// Socket ops with fd in arg1
+translate_fd1_handler!(setsockopt_handler,       SYS_SETSOCKOPT);
+translate_fd1_handler!(getsockopt_handler,       SYS_GETSOCKOPT);
+translate_fd1_handler!(getsockname_handler,      SYS_GETSOCKNAME);
+translate_fd1_handler!(getpeername_handler,      SYS_GETPEERNAME);
+translate_fd1_handler!(sendto_handler,           SYS_SENDTO);
+translate_fd1_handler!(recvfrom_handler,         SYS_RECVFROM);
+translate_fd1_handler!(sendmsg_handler,          SYS_SENDMSG);
+translate_fd1_handler!(recvmsg_handler,          SYS_RECVMSG);
+
+/// accept4 (syscall 288): like accept but with flags.  IPC sockets get
+/// handled in accept_handler logic; for non-IPC sockets we translate +
+/// register a fresh grate vfd just like accept.
+pub extern "C" fn accept4_handler(
+    _cageid: u64,
+    arg1: u64, arg1cage: u64,    // listening fd
+    arg2: u64, arg2cage: u64,    // addr
+    arg3: u64, arg3cage: u64,    // addrlen
+    arg4: u64, arg4cage: u64,    // flags
+    arg5: u64, arg5cage: u64,
+    arg6: u64, arg6cage: u64,
+) -> i32 {
+    let cage_id = arg1cage;
+    let fd = arg1;
+    let args = [arg1, arg2, arg3, arg4, arg5, arg6];
+    let arg_cages = [arg1cage, arg2cage, arg3cage, arg4cage, arg5cage, arg6cage];
+
+    let info = lookup_ipc_fd(cage_id, fd);
+    if info.is_some() {
+        // Defer to accept_handler for IPC sockets (flags currently ignored).
+        return accept_handler(
+            _cageid, arg1, arg1cage, arg2, arg2cage, arg3, arg3cage,
+            arg4, arg4cage, arg5, arg5cage, arg6, arg6cage,
+        );
+    }
+
+    let under = match translate_to_underfd(cage_id, fd) {
+        Some(u) => u,
+        None => return EBADF_NEG,
+    };
+    let mut t = args;
+    t[0] = under;
+    let new_runtime_vfd = forward_syscall(SYS_ACCEPT4, cage_id, &t, &arg_cages);
+    if new_runtime_vfd < 0 {
+        return new_runtime_vfd;
+    }
+    let cloexec = (arg4 as i32 & O_CLOEXEC) != 0;
+    register_kernel_fd(cage_id, new_runtime_vfd, cloexec, 0)
+}
+
+/// mmap (syscall 9): the fd is in arg5; translate it.  Pass through
+/// when the mapping is anonymous (MAP_ANON set in arg4) — fd is unused
+/// in that case and may be -1.
+pub extern "C" fn mmap_handler(
+    _cageid: u64,
+    arg1: u64, arg1cage: u64,    // addr
+    arg2: u64, arg2cage: u64,    // length
+    arg3: u64, arg3cage: u64,    // prot
+    arg4: u64, arg4cage: u64,    // flags
+    arg5: u64, arg5cage: u64,    // fd
+    arg6: u64, arg6cage: u64,    // offset
+) -> i32 {
+    let cage_id = arg1cage;
+    let mut args = [arg1, arg2, arg3, arg4, arg5, arg6];
+    let arg_cages = [arg1cage, arg2cage, arg3cage, arg4cage, arg5cage, arg6cage];
+
+    let is_anon = (arg4 as i32) & grate_rs::constants::mman::MAP_ANON != 0;
+    if !is_anon {
+        match translate_to_underfd(cage_id, arg5) {
+            Some(u) => args[4] = u,
+            None => return EBADF_NEG,
+        }
+    }
+    forward_syscall(SYS_MMAP, cage_id, &args, &arg_cages)
 }

--- a/rust-grates/ipc-grate/src/helpers.rs
+++ b/rust-grates/ipc-grate/src/helpers.rs
@@ -1,8 +1,13 @@
 //! Shared helpers for the IPC grate.
 
-use grate_rs::{getcageid, make_threei_call};
+use grate_rs::{GrateError, getcageid, make_threei_call};
 
 /// Forward a syscall to the next handler via make_threei_call.
+///
+/// Pass `translate_errno=0` so the lower layer returns its raw negative
+/// errno (e.g. -ENOENT) instead of -1.  We then surface that errno
+/// directly to the caller — callers like initdb branch on `errno ==
+/// ENOENT` and a collapsed -1/-EPERM masks the real condition.
 pub fn forward_syscall(
     nr: u64, calling_cage: u64,
     args: &[u64; 6], arg_cages: &[u64; 6],
@@ -14,6 +19,7 @@ pub fn forward_syscall(
         args[3], arg_cages[3], args[4], arg_cages[4], args[5], arg_cages[5], 0,
     ) {
         Ok(r) => r,
+        Err(GrateError::MakeSyscallError(n)) => n,
         Err(_) => -1,
     }
 }

--- a/rust-grates/ipc-grate/src/ipc.rs
+++ b/rust-grates/ipc-grate/src/ipc.rs
@@ -143,14 +143,28 @@ impl IpcState {
 /// Check if a fd belongs to the IPC grate (pipe endpoint or socket).
 /// Returns (underfd, fdkind, flags) or None if it's not ours.
 ///
-/// If the cage doesn't exist in fdtables yet (fork in progress on another
-/// runtime thread), spin-waits until it appears.  DashMap's internal locking
-/// provides the cross-thread visibility that std::sync::Mutex and POSIX
-/// semaphores cannot in the Lind WASM environment.
+/// If the cage doesn't exist in fdtables yet, init it empty.  This
+/// covers the vfork-spawn case: posix_spawn issues
+/// `clone(CLONE_VM | CLONE_VFORK)` which suspends the parent inside
+/// the runtime's clone until the child execs.  The child runs
+/// syscalls (dup2/close for redirection, etc.) before our parent
+/// fork_handler returns from forward_syscall and gets to call
+/// `copy_fdtable_for_cage`.  Without on-demand init, the child either
+/// spins forever (with the old spin-wait) or panics in
+/// `translate_virtual_fd`'s `check_cage_exists` assert.
+///
+/// Init-on-demand here means the spawned cage starts with an empty
+/// fdtable in our grate.  IPC operations on inherited fds will not
+/// find entries (so they fall through to forward_syscall, which is
+/// fine — under CLONE_VM the runtime handles fd state via the
+/// shared VM with the parent).
 pub fn lookup_ipc_fd(cage_id: u64, fd: u64) -> Option<(u64, u32, i32)> {
-    // Spin until cage is set up by fork_handler on the parent's thread.
-    while !fdtables::check_cage_exists(cage_id) {
-        std::thread::yield_now();
+    if !fdtables::check_cage_exists(cage_id) {
+        // Vfork-spawn child may run syscalls before our parent
+        // fork_handler can copy_fdtable_for_cage; init the cage empty
+        // on demand and let the syscall fall through to forward.
+        fdtables::init_empty_cage(cage_id);
+        return None;
     }
     match fdtables::translate_virtual_fd(cage_id, fd) {
         Ok(entry) if entry.fdkind == IPC_PIPE || entry.fdkind == IPC_SOCKET => {

--- a/rust-grates/ipc-grate/src/main.rs
+++ b/rust-grates/ipc-grate/src/main.rs
@@ -23,6 +23,24 @@ fn main() {
     let grate_cage_id = getcageid();
     init(grate_cage_id);
 
+    // Register fdtables-level close handlers so refcount decrements
+    // happen automatically on all entry-removal paths: close_virtualfd,
+    // get_specific_virtual_fd overwrite, empty_fds_for_exec, AND
+    // remove_cage_from_fdtable (cage exit).  Without this, e.g. a
+    // process exiting (postgres backend after locale enumeration)
+    // doesn't decrement pipe.write_refs, so the parent's fgets / poll
+    // never sees EOF.
+    fdtables::register_close_handlers(
+        ipc::IPC_PIPE,
+        handlers::ipc_pipe_close_handler,
+        handlers::ipc_pipe_close_handler,
+    );
+    fdtables::register_close_handlers(
+        socket::IPC_SOCKET,
+        handlers::ipc_socket_close_handler,
+        handlers::ipc_socket_close_handler,
+    );
+
     let argv: Vec<String> = std::env::args().skip(1).collect();
 
     GrateBuilder::new()
@@ -32,11 +50,43 @@ fn main() {
         // I/O syscalls (handle both pipes and sockets)
         .register(SYS_READ, handlers::read_handler)
         .register(SYS_WRITE, handlers::write_handler)
+        .register(SYS_OPEN, handlers::open_handler)
+        .register(SYS_OPENAT, handlers::openat_handler)
         .register(SYS_CLOSE, handlers::close_handler)
         .register(SYS_DUP, handlers::dup_handler)
         .register(SYS_DUP2, handlers::dup2_handler)
         .register(SYS_DUP3, handlers::dup3_handler)
         .register(SYS_FCNTL, handlers::fcntl_handler)
+        .register(SYS_POLL, handlers::poll_handler)
+        .register(SYS_SELECT, handlers::select_handler)
+        // Pure-translation handlers for fd-taking syscalls — they
+        // translate the grate vfd in arg1 to its runtime vfd before
+        // forwarding to RawPOSIX, since the two fdtable instances are
+        // independent.
+        .register(SYS_LSEEK, handlers::lseek_handler)
+        .register(SYS_IOCTL, handlers::ioctl_handler)
+        .register(SYS_FSTAT, handlers::fstat_handler)
+        .register(SYS_FSYNC, handlers::fsync_handler)
+        .register(SYS_FDATASYNC, handlers::fdatasync_handler)
+        .register(SYS_FTRUNCATE, handlers::ftruncate_handler)
+        .register(SYS_GETDENTS, handlers::getdents_handler)
+        .register(SYS_FSTATFS, handlers::fstatfs_handler)
+        .register(SYS_FCHDIR, handlers::fchdir_handler)
+        .register(SYS_FCHMOD, handlers::fchmod_handler)
+        .register(SYS_FLOCK, handlers::flock_handler)
+        .register(SYS_PREAD, handlers::pread_handler)
+        .register(SYS_PWRITE, handlers::pwrite_handler)
+        .register(SYS_READV, handlers::readv_handler)
+        .register(SYS_WRITEV, handlers::writev_handler)
+        .register(SYS_PREADV, handlers::preadv_handler)
+        .register(SYS_PWRITEV, handlers::pwritev_handler)
+        .register(SYS_SYNC_FILE_RANGE, handlers::sync_file_range_handler)
+        .register(SYS_MMAP, handlers::mmap_handler)
+        .register(SYS_PPOLL, handlers::ppoll_handler)
+        .register(SYS_EPOLL_CREATE, handlers::epoll_create_handler)
+        .register(SYS_EPOLL_CREATE1, handlers::epoll_create1_handler)
+        .register(SYS_EPOLL_CTL, handlers::epoll_ctl_handler)
+        .register(SYS_EPOLL_WAIT, handlers::epoll_wait_handler)
         // Socket syscalls
         .register(SYS_SOCKET, handlers::socket_handler)
         .register(SYS_SOCKETPAIR, handlers::socketpair_handler)
@@ -44,10 +94,21 @@ fn main() {
         .register(SYS_LISTEN, handlers::listen_handler)
         .register(SYS_CONNECT, handlers::connect_handler)
         .register(SYS_ACCEPT, handlers::accept_handler)
+        .register(SYS_ACCEPT4, handlers::accept4_handler)
         .register(SYS_SHUTDOWN, handlers::shutdown_handler)
+        .register(SYS_SETSOCKOPT, handlers::setsockopt_handler)
+        .register(SYS_GETSOCKOPT, handlers::getsockopt_handler)
+        .register(SYS_GETSOCKNAME, handlers::getsockname_handler)
+        .register(SYS_GETPEERNAME, handlers::getpeername_handler)
+        .register(SYS_SENDTO, handlers::sendto_handler)
+        .register(SYS_RECVFROM, handlers::recvfrom_handler)
+        .register(SYS_SENDMSG, handlers::sendmsg_handler)
+        .register(SYS_RECVMSG, handlers::recvmsg_handler)
         // Lifecycle
         .register(SYS_CLONE, handlers::fork_handler)
         .register(SYS_EXEC, handlers::exec_handler)
+        .register(SYS_EXIT, handlers::exit_handler)
+        .register(SYS_EXIT_GROUP, handlers::exit_group_handler)
         .preexec(|child_cage: i32| {
             let cage_id = child_cage as u64;
             fdtables::init_empty_cage(cage_id);

--- a/rust-grates/ipc-grate/test/fcntl_setfl_test.c
+++ b/rust-grates/ipc-grate/test/fcntl_setfl_test.c
@@ -1,0 +1,88 @@
+/* fcntl_setfl_test.c — regression for F_SETFL access-mode preservation.
+ *
+ * Postgres calls fcntl(F_SETFL, O_NONBLOCK) on its self-pipe ends.
+ * Earlier we had a bug where this overwrote perfdinfo entirely,
+ * wiping the O_RDONLY/O_WRONLY access-mode bits we use to distinguish
+ * pipe read-end from write-end.  Fixed in commit 942c8b0.  This test
+ * exercises the path:
+ *
+ *   1. pipe(p) — read end gets O_RDONLY, write end gets O_WRONLY
+ *   2. F_GETFL on each — sanity: access mode is correct
+ *   3. F_SETFL O_NONBLOCK on each
+ *   4. F_GETFL on each — access mode must STILL be correct,
+ *      O_NONBLOCK must now be set
+ *   5. write to write end, read from read end — must still work
+ *      (broken access-mode would make our handler return EBADF)
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+
+#define O_NONBLOCK 04000  /* same value as Linux */
+#define O_ACCMODE  03
+
+static int fail_count = 0;
+#define EXPECT(cond, msg) do { \
+    if (!(cond)) { \
+        fprintf(stderr, "FAIL: %s\n", msg); \
+        fail_count++; \
+    } \
+} while (0)
+
+int main(void) {
+    int p[2];
+    if (pipe(p) != 0) {
+        fprintf(stderr, "pipe failed: errno=%d\n", errno);
+        return 1;
+    }
+
+    int read_flags  = fcntl(p[0], F_GETFL, 0);
+    int write_flags = fcntl(p[1], F_GETFL, 0);
+    EXPECT((read_flags  & O_ACCMODE) == 0, "read end access mode != O_RDONLY before F_SETFL");
+    EXPECT((write_flags & O_ACCMODE) == 1, "write end access mode != O_WRONLY before F_SETFL");
+
+    /* Set O_NONBLOCK on both. */
+    int rc;
+    rc = fcntl(p[0], F_SETFL, O_NONBLOCK);
+    EXPECT(rc == 0, "F_SETFL O_NONBLOCK on read end failed");
+    rc = fcntl(p[1], F_SETFL, O_NONBLOCK);
+    EXPECT(rc == 0, "F_SETFL O_NONBLOCK on write end failed");
+
+    /* Re-read flags and check both access mode AND O_NONBLOCK. */
+    read_flags  = fcntl(p[0], F_GETFL, 0);
+    write_flags = fcntl(p[1], F_GETFL, 0);
+    printf("post-F_SETFL: read_flags=0x%x write_flags=0x%x\n",
+           read_flags, write_flags);
+
+    EXPECT((read_flags  & O_ACCMODE) == 0,
+           "read end access mode CLOBBERED by F_SETFL (regression)");
+    EXPECT((write_flags & O_ACCMODE) == 1,
+           "write end access mode CLOBBERED by F_SETFL (regression)");
+    EXPECT((read_flags  & O_NONBLOCK) != 0,
+           "O_NONBLOCK not set on read end after F_SETFL");
+    EXPECT((write_flags & O_NONBLOCK) != 0,
+           "O_NONBLOCK not set on write end after F_SETFL");
+
+    /* Write to write end and read from read end — verifies our
+     * is_read_end / is_write_end checks still pass after F_SETFL. */
+    char b = 'Z';
+    ssize_t nw = write(p[1], &b, 1);
+    EXPECT(nw == 1, "write to write-end after F_SETFL returned wrong count (EBADF would be -1)");
+
+    char rb = 0;
+    ssize_t nr = read(p[0], &rb, 1);
+    EXPECT(nr == 1 && rb == 'Z', "read from read-end after F_SETFL returned wrong data");
+
+    close(p[0]);
+    close(p[1]);
+
+    if (fail_count == 0) {
+        printf("fcntl_setfl_test: PASS\n");
+        return 0;
+    }
+    printf("fcntl_setfl_test: %d failures\n", fail_count);
+    return 1;
+}

--- a/rust-grates/ipc-grate/test/file_collision_reader.c
+++ b/rust-grates/ipc-grate/test/file_collision_reader.c
@@ -1,0 +1,74 @@
+/* file_collision_reader.c — Helper for the fd-collision test.
+ *
+ * The parent execs this binary with leaked IPC pipe fds still in the
+ * grate's fdtable. The kernel knows nothing about those pipes, so the
+ * first open() here will return a low fd (typically 3) that overlaps
+ * a stale grate IPC entry.
+ *
+ * If the IPC grate's exec_handler did NOT clean up its fdtable, the
+ * grate intercepts read/write on those kernel-allocated fds and routes
+ * them to dead pipes — typically returning EBADF (write to read-end /
+ * read from write-end), short reads, or zero bytes. Any of those make
+ * the verify step below fail.
+ *
+ * Open several files in succession to maximize the chance of hitting a
+ * collided fd, since we don't know the exact numbering the kernel will
+ * choose.
+ *
+ * Exit codes: 0 on success, non-zero on any I/O mismatch.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+
+#define NFILES 6
+
+int main(void) {
+    const char *pattern = "HELLO_NO_COLLISION_0123456789";
+    size_t plen = strlen(pattern);
+
+    int fds[NFILES];
+    char paths[NFILES][64];
+
+    for (int i = 0; i < NFILES; i++) {
+        snprintf(paths[i], sizeof(paths[i]), "/tmp/ipc_collision_%d.tmp", i);
+        fds[i] = open(paths[i], O_RDWR | O_CREAT | O_TRUNC, 0644);
+        if (fds[i] < 0) {
+            fprintf(stderr, "open(%s) failed: errno=%d\n", paths[i], errno);
+            return 2;
+        }
+
+        ssize_t nw = write(fds[i], pattern, plen);
+        if (nw != (ssize_t)plen) {
+            fprintf(stderr, "write fd=%d returned %zd (expected %zu) errno=%d\n",
+                    fds[i], nw, plen, errno);
+            return 1;
+        }
+
+        if (lseek(fds[i], 0, SEEK_SET) < 0) {
+            fprintf(stderr, "lseek fd=%d failed: errno=%d\n", fds[i], errno);
+            return 2;
+        }
+
+        char buf[64] = {0};
+        ssize_t nr = read(fds[i], buf, sizeof(buf) - 1);
+        if (nr != (ssize_t)plen) {
+            fprintf(stderr, "read fd=%d returned %zd (expected %zu) errno=%d\n",
+                    fds[i], nr, plen, errno);
+            return 1;
+        }
+        if (memcmp(buf, pattern, plen) != 0) {
+            fprintf(stderr, "fd=%d content mismatch: got \"%s\"\n", fds[i], buf);
+            return 1;
+        }
+    }
+
+    for (int i = 0; i < NFILES; i++) {
+        close(fds[i]);
+        unlink(paths[i]);
+    }
+    return 0;
+}

--- a/rust-grates/ipc-grate/test/ipc_test.c
+++ b/rust-grates/ipc-grate/test/ipc_test.c
@@ -534,6 +534,195 @@ static void test_rapid_pipe_lifecycle(void) {
     }
 }
 
+/* ── Test 17: popen pattern — dup2 pipe to stdin then exec ────────── */
+/* Simulates what popen("cmd", "w") does: parent writes to pipe,
+ * child dup2's read end to stdin, execs a program that reads stdin.
+ * Tests 4KB, 64KB (pipe buffer size), and 256KB transfers. */
+
+static void test_popen_exec_helper(const char *desc, long nbytes) {
+    int pipefd[2];
+    pipe(pipefd);
+
+    pid_t pid = fork();
+    if (pid == 0) {
+        /* Child: popen pattern — redirect pipe read end to stdin, exec reader */
+        close(pipefd[1]);       /* close write end */
+        dup2(pipefd[0], 0);     /* pipe read end -> stdin */
+        close(pipefd[0]);       /* close original fd */
+
+        /* exec the reader with expected byte count */
+        char countbuf[32];
+        snprintf(countbuf, sizeof(countbuf), "%ld", nbytes);
+        execl("pipe_stdin_reader.cwasm", "pipe_stdin_reader.cwasm", countbuf, NULL);
+        /* if exec fails */
+        perror("execl failed");
+        _exit(2);
+    }
+
+    /* Parent: write pattern data to pipe */
+    close(pipefd[0]);
+
+    char wbuf[4096];
+    long total = 0;
+    while (total < nbytes) {
+        long chunk = nbytes - total;
+        if (chunk > 4096) chunk = 4096;
+        for (long i = 0; i < chunk; i++)
+            wbuf[i] = 'A' + ((total + i) % 26);
+        ssize_t nw = write(pipefd[1], wbuf, chunk);
+        if (nw <= 0) break;
+        total += nw;
+    }
+    close(pipefd[1]);
+
+    int status;
+    waitpid(pid, &status, 0);
+
+    CHECK(desc, WIFEXITED(status) && WEXITSTATUS(status) == 0);
+}
+
+static void test_popen_exec(void) {
+    printf("\n[test_popen_exec]\n");
+
+    test_popen_exec_helper("popen pattern: 4KB through exec'd stdin", 4096);
+    test_popen_exec_helper("popen pattern: 64KB through exec'd stdin", 65536);
+    test_popen_exec_helper("popen pattern: 256KB through exec'd stdin", 256 * 1024);
+}
+
+/* ── Test: basic file I/O through the IPC grate ───────────────────── */
+/* Sanity check that the IPC grate's open/close/read/write handlers
+ * correctly forward non-IPC file operations to the kernel.  No pipes,
+ * no fork — just open a file, write a pattern, close, reopen, read,
+ * verify. */
+
+static void test_file_io_basic(void) {
+    printf("\n[test_file_io_basic]\n");
+
+    const char *path = "/tmp/ipc_grate_basic_io.tmp";
+    const char *pattern = "ipc-grate-basic-file-io-check";
+    size_t plen = strlen(pattern);
+
+    int fd = open(path, O_RDWR | O_CREAT | O_TRUNC, 0644);
+    CHECK("open(O_RDWR|O_CREAT) returns valid fd", fd >= 0);
+    if (fd < 0) return;
+
+    ssize_t nw = write(fd, pattern, plen);
+    CHECK("write() to file returns full length", nw == (ssize_t)plen);
+
+    CHECK("close(fd) succeeds", close(fd) == 0);
+
+    fd = open(path, O_RDONLY);
+    CHECK("reopen O_RDONLY returns valid fd", fd >= 0);
+    if (fd < 0) { unlink(path); return; }
+
+    char buf[64] = {0};
+    ssize_t nr = read(fd, buf, sizeof(buf) - 1);
+    CHECK("read() returns full length",
+          nr == (ssize_t)plen && memcmp(buf, pattern, plen) == 0);
+
+    CHECK("close(fd) after read succeeds", close(fd) == 0);
+
+    unlink(path);
+}
+
+/* ── Test 17b: fd collision after exec ───────────────────────────── */
+/* Parent creates a pipe and forks. Child deliberately leaks both pipe
+ * fds (does not close them) and execs a helper that opens kernel files.
+ * Without the exec_handler IPC cleanup, the grate's fdtable still holds
+ * IPC entries on the inherited pipe fds; when the helper's open() returns
+ * those same fd numbers from the kernel, read/write on them gets routed
+ * to the dead pipe instead of the file, and the helper exits non-zero.
+ */
+static void test_fd_collision_after_exec(void) {
+    printf("\n[test_fd_collision_after_exec]\n");
+
+    int pipefd[2];
+    if (pipe(pipefd) != 0) {
+        printf("  FAIL: pipe() errno=%d\n", errno);
+        tests_run++;
+        return;
+    }
+
+    pid_t pid = fork();
+    if (pid == 0) {
+        /* Intentionally do NOT close pipefd[0]/pipefd[1].  The grate's
+         * fdtable will still hold IPC pipe entries on those fd numbers
+         * across the exec, shadowing kernel-allocated file fds in the
+         * exec'd program. */
+        execl("file_collision_reader.cwasm", "file_collision_reader.cwasm", NULL);
+        perror("execl failed");
+        _exit(2);
+    }
+
+    /* Parent: drop pipe ends so the child's read end (if it ever gets
+     * used) hits EOF promptly. */
+    close(pipefd[0]);
+    close(pipefd[1]);
+
+    int status;
+    waitpid(pid, &status, 0);
+    CHECK("file I/O after exec with leaked pipe fds",
+          WIFEXITED(status) && WEXITSTATUS(status) == 0);
+}
+
+/* ── Test 18: Large pipe transfer correctness ─────────────────────── */
+/* Verifies byte-level correctness for transfers larger than the pipe
+ * buffer (65KB). Tests 128KB and 512KB across a fork. */
+
+static void test_large_pipe_correctness_helper(const char *desc, long nbytes) {
+    int pipefd[2];
+    pipe(pipefd);
+
+    pid_t pid = fork();
+    if (pid == 0) {
+        /* Child: writer */
+        close(pipefd[0]);
+        char wbuf[4096];
+        long total = 0;
+        while (total < nbytes) {
+            long chunk = nbytes - total;
+            if (chunk > 4096) chunk = 4096;
+            for (long i = 0; i < chunk; i++)
+                wbuf[i] = 'A' + ((total + i) % 26);
+            ssize_t nw = write(pipefd[1], wbuf, chunk);
+            if (nw <= 0) _exit(1);
+            total += nw;
+        }
+        close(pipefd[1]);
+        _exit(0);
+    }
+
+    /* Parent: reader */
+    close(pipefd[1]);
+
+    char rbuf[4096];
+    long total = 0;
+    int ok = 1;
+    while (total < nbytes) {
+        ssize_t nr = read(pipefd[0], rbuf, sizeof(rbuf));
+        if (nr <= 0) { ok = 0; break; }
+        for (long i = 0; i < nr; i++) {
+            char want = 'A' + ((total + i) % 26);
+            if (rbuf[i] != want) { ok = 0; break; }
+        }
+        if (!ok) break;
+        total += nr;
+    }
+    if (total != nbytes) ok = 0;
+
+    close(pipefd[0]);
+    waitpid(pid, NULL, 0);
+
+    CHECK(desc, ok);
+}
+
+static void test_large_pipe_correctness(void) {
+    printf("\n[test_large_pipe_correctness]\n");
+
+    test_large_pipe_correctness_helper("128KB pipe transfer correct", 128 * 1024);
+    test_large_pipe_correctness_helper("512KB pipe transfer correct", 512 * 1024);
+}
+
 /* ── Main ──────────────────────────────────────────────────────────── */
 
 int main(void) {
@@ -555,6 +744,10 @@ int main(void) {
     test_dup2_overwrite();
     test_socketpair_fork();
     test_rapid_pipe_lifecycle();
+    test_popen_exec();
+    test_file_io_basic();
+    test_fd_collision_after_exec();
+    test_large_pipe_correctness();
 
     printf("\n=== results: %d/%d passed ===\n", tests_passed, tests_run);
     return (tests_passed == tests_run) ? 0 : 1;

--- a/rust-grates/ipc-grate/test/pipe_stdin_reader.c
+++ b/rust-grates/ipc-grate/test/pipe_stdin_reader.c
@@ -1,0 +1,63 @@
+/* pipe_stdin_reader.c — Helper binary for popen/exec pipe tests.
+ *
+ * Reads all data from stdin, verifies it matches expected pattern,
+ * exits 0 on success, 1 on mismatch, 2 on read error.
+ *
+ * Expected pattern: repeating 'A' + (offset % 26) for the number of
+ * bytes specified as argv[1].
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+int main(int argc, char *argv[]) {
+    if (argc < 2) {
+        fprintf(stderr, "Usage: pipe_stdin_reader <expected_bytes>\n");
+        return 2;
+    }
+
+    long expected = atol(argv[1]);
+    if (expected <= 0 || expected > 4 * 1024 * 1024) {
+        fprintf(stderr, "Invalid byte count: %s\n", argv[1]);
+        return 2;
+    }
+
+    char *buf = malloc(expected);
+    if (!buf) {
+        fprintf(stderr, "malloc failed\n");
+        return 2;
+    }
+
+    long total = 0;
+    while (total < expected) {
+        ssize_t n = read(STDIN_FILENO, buf + total, expected - total);
+        if (n < 0) {
+            fprintf(stderr, "read error at offset %ld\n", total);
+            free(buf);
+            return 2;
+        }
+        if (n == 0) break; /* EOF */
+        total += n;
+    }
+
+    if (total != expected) {
+        fprintf(stderr, "short read: got %ld, expected %ld\n", total, expected);
+        free(buf);
+        return 1;
+    }
+
+    /* Verify pattern */
+    for (long i = 0; i < expected; i++) {
+        char want = 'A' + (i % 26);
+        if (buf[i] != want) {
+            fprintf(stderr, "mismatch at offset %ld: got 0x%02x, want 0x%02x\n",
+                    i, (unsigned char)buf[i], (unsigned char)want);
+            free(buf);
+            return 1;
+        }
+    }
+
+    free(buf);
+    return 0;
+}

--- a/rust-grates/ipc-grate/test/poll_pipe_test.c
+++ b/rust-grates/ipc-grate/test/poll_pipe_test.c
@@ -1,0 +1,75 @@
+/* poll_pipe_test.c — direct test for poll() on an IPC pipe.
+ *
+ * This is the self-pipe trick that postgres uses: create a pipe,
+ * write a byte to it, then poll() the read end for POLLIN.  Under a
+ * working pipe, poll returns immediately with POLLIN set.
+ *
+ * The IPC grate doesn't intercept SYS_POLL, so poll forwards to
+ * RawPOSIX whose fdtables knows nothing about our userspace pipe.
+ * Expected (broken) behavior: poll either times out (returns 0) or
+ * blocks forever, even though the pipe has data.
+ *
+ * Usage:
+ *   lind-wasm --enable-fpcast /grates/ipc-grate.cwasm poll_pipe_test.cwasm
+ *
+ * Exit codes:
+ *   0  — pass: poll correctly reported POLLIN
+ *   1  — pipe() failed
+ *   2  — write to pipe failed
+ *   3  — poll returned 0 (timeout)  -- broken poll integration
+ *   4  — poll returned negative (error)
+ *   5  — poll returned > 0 but POLLIN wasn't set
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <errno.h>
+#include <poll.h>
+
+int main(void) {
+    int pipefd[2];
+    if (pipe(pipefd) != 0) {
+        fprintf(stderr, "pipe failed: errno=%d\n", errno);
+        return 1;
+    }
+
+    /* Put a byte into the write end so poll on the read end should
+     * see POLLIN immediately. */
+    char b = 'X';
+    ssize_t nw = write(pipefd[1], &b, 1);
+    if (nw != 1) {
+        fprintf(stderr, "write to pipe returned %zd, errno=%d\n", nw, errno);
+        return 2;
+    }
+
+    struct pollfd pfd = {
+        .fd = pipefd[0],
+        .events = POLLIN,
+        .revents = 0,
+    };
+
+    /* 500ms timeout — generous; a working poll() returns ~immediately. */
+    int rc = poll(&pfd, 1, 500);
+
+    if (rc == 0) {
+        fprintf(stderr, "poll TIMED OUT despite pipe having data — "
+                        "poll integration with IPC pipe is broken\n");
+        return 3;
+    }
+    if (rc < 0) {
+        fprintf(stderr, "poll returned -1, errno=%d\n", errno);
+        return 4;
+    }
+    if (!(pfd.revents & POLLIN)) {
+        fprintf(stderr, "poll returned %d but revents=0x%x (POLLIN not set)\n",
+                rc, pfd.revents);
+        return 5;
+    }
+
+    printf("poll_pipe_test: PASS (poll saw POLLIN on pipe with data)\n");
+
+    close(pipefd[0]);
+    close(pipefd[1]);
+    return 0;
+}

--- a/rust-grates/ipc-grate/test/select_pipe_test.c
+++ b/rust-grates/ipc-grate/test/select_pipe_test.c
@@ -1,0 +1,60 @@
+/* select_pipe_test.c — direct test for select() on an IPC pipe.
+ *
+ * Mirrors poll_pipe_test but for select().  Create a pipe, write a
+ * byte, select on the read end with POLLIN-equivalent.  Verify
+ * FD_ISSET(read_fd, &readfds).
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <errno.h>
+#include <sys/select.h>
+
+int main(void) {
+    int pipefd[2];
+    if (pipe(pipefd) != 0) {
+        fprintf(stderr, "pipe failed: errno=%d\n", errno);
+        return 1;
+    }
+
+    char b = 'X';
+    ssize_t nw = write(pipefd[1], &b, 1);
+    if (nw != 1) {
+        fprintf(stderr, "write returned %zd, errno=%d\n", nw, errno);
+        return 2;
+    }
+
+    fd_set readfds;
+    FD_ZERO(&readfds);
+    FD_SET(pipefd[0], &readfds);
+
+    struct timeval tv = { .tv_sec = 0, .tv_usec = 500 * 1000 };  /* 500ms */
+    int rc = select(pipefd[0] + 1, &readfds, NULL, NULL, &tv);
+
+    if (rc == 0) {
+        fprintf(stderr, "select TIMED OUT despite pipe having data\n");
+        return 3;
+    }
+    if (rc < 0) {
+        fprintf(stderr, "select returned -1 errno=%d\n", errno);
+        return 4;
+    }
+    if (!FD_ISSET(pipefd[0], &readfds)) {
+        fprintf(stderr, "select returned %d but read-end not in readfds\n", rc);
+        return 5;
+    }
+
+    /* Drain the byte to confirm there's actually data there. */
+    char rb = 0;
+    ssize_t nr = read(pipefd[0], &rb, 1);
+    if (nr != 1 || rb != 'X') {
+        fprintf(stderr, "read mismatch: nr=%zd byte=0x%02x\n", nr, (unsigned char) rb);
+        return 6;
+    }
+
+    printf("select_pipe_test: PASS (select saw read-end ready, byte verified)\n");
+    close(pipefd[0]);
+    close(pipefd[1]);
+    return 0;
+}

--- a/test/grates_test.toml
+++ b/test/grates_test.toml
@@ -176,6 +176,7 @@ type = "rust"
 
 [[grate.tests]]
 test_src = "test/ipc_test.c"
+files = ["test/pipe_stdin_reader.c", "test/file_collision_reader.c"]
 timeout = 120
 
 # ── Net Routing Clamp (Rust) ────────────────────────────────────────


### PR DESCRIPTION
The grate maintains its own fdtables instance (in wasm linear memory), separate from RawPOSIX's host-side fdtables.  Previously the grate identity-mapped the runtime's vfd numbers, so any open() in a cage that already had IPC pipe entries would clobber them.  Postgres tripped this with postmaster_alive_fds at fds 3,4 followed by config-file opens.

Switch to real translation:

  * Fd-creating handlers (open, openat, dup, socket, accept, accept4, epoll_create*) allocate a fresh grate vfd via get_unused_virtual_fd whose underfd is the runtime's vfd.

  * All forwarding handlers translate the user's grate vfd to its underfd before calling forward_syscall.  Translation-only handlers are registered for the long tail of fd-taking syscalls (lseek, ioctl, fstat, sendto/recvfrom/sendmsg/recvmsg, getsockopt/setsockopt, getsockname/getpeername, fchdir, fchmod, fsync, fdatasync, ftruncate, flock, sync_file_range, getdents, fstatfs, *v variants, mmap, ppoll, epoll_*).

  * poll/select translate kernel fds in their fd lists/sets and reconstruct user-visible grate vfds in the result.

  * AF_INET loopback take-over now closes the runtime vfd via translate_to_underfd before overwriting the grate-side entry as IPC_SOCKET.

Other fixes folded in:

  * fork_handler snapshots the parent's grate fdtable and re-installs IPC entries explicitly in the child after copy_fdtable_for_cage, in case RawPOSIX populated the child cage first.
  * exec_handler relies on registered fdtables close handlers to decrement IPC pipe/socket refcounts on cloexec sweep.
  * exit_handler / exit_group_handler remove the cage from our fdtable so refs drop on cage exit.
  * bind_handler creates a placeholder file for AF_UNIX paths so chmod/unlink work after bind.
  * fcntl(F_SETFL) preserves access-mode bits (otherwise pipe direction was wiped).
  * forward_syscall surfaces the raw negative errno from the runtime instead of collapsing to -1.