### PR TITLE
Switch all Rust grates to fdtables muthashmax backend

### DIFF
--- a/rust-grates/devnull-grate/Cargo.toml
+++ b/rust-grates/devnull-grate/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2024"
 
 [dependencies]
 grate-rs = { git = "https://github.com/Lind-Project/lind-wasm-example-grates", branch = "main", subdir = "lib/grate-rs" }
-fdtables = { git = "https://github.com/Lind-Project/lind-wasm", branch = "main", subdir = "src/fdtables" }
+fdtables = { git = "https://github.com/Lind-Project/lind-wasm", branch = "main", subdir = "src/fdtables", default-features = false, features = ["muthashmax"] }
 libc = "0.2"

--- a/rust-grates/fdtables-test-grate/Cargo.toml
+++ b/rust-grates/fdtables-test-grate/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2024"
 
 [dependencies]
 grate-rs = { git = "https://github.com/Lind-Project/lind-wasm-example-grates", branch = "main", subdir = "lib/grate-rs" }
-fdtables = { git = "https://github.com/Lind-Project/lind-wasm", branch = "main", subdir = "src/fdtables" }
+fdtables = { git = "https://github.com/Lind-Project/lind-wasm", branch = "main", subdir = "src/fdtables", default-features = false, features = ["muthashmax"] }
 libc = "0.2"

--- a/rust-grates/fs-routing-clamp/Cargo.toml
+++ b/rust-grates/fs-routing-clamp/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2024"
 
 [dependencies]
 grate-rs = { git = "https://github.com/Lind-Project/lind-wasm-example-grates", branch= "main", subdir = "lib/grate-rs"  }
-fdtables = { git = "https://github.com/Lind-Project/lind-wasm", branch = "main", subdir = "src/fdtables" }
+fdtables = { git = "https://github.com/Lind-Project/lind-wasm", branch = "main", subdir = "src/fdtables", default-features = false, features = ["muthashmax"] }
 libc = "0.2"

--- a/rust-grates/imfs-grate/Cargo.toml
+++ b/rust-grates/imfs-grate/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2024"
 
 [dependencies]
 grate-rs = { git = "https://github.com/Lind-Project/lind-wasm-example-grates", branch= "main", subdir = "lib/grate-rs"  }
-fdtables = { git = "https://github.com/Lind-Project/lind-wasm", branch = "main", subdir = "src/fdtables" }
+fdtables = { git = "https://github.com/Lind-Project/lind-wasm", branch = "main", subdir = "src/fdtables", default-features = false, features = ["muthashmax"] }
 libc = "0.2"

--- a/rust-grates/ipc-grate/Cargo.toml
+++ b/rust-grates/ipc-grate/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2024"
 
 [dependencies]
 grate-rs = { git = "https://github.com/Lind-Project/lind-wasm-example-grates", branch = "main", subdir = "lib/grate-rs" }
-fdtables = { git = "https://github.com/Lind-Project/lind-wasm", branch = "main", subdir = "src/fdtables" }
+fdtables = { git = "https://github.com/Lind-Project/lind-wasm", branch = "main", subdir = "src/fdtables", default-features = false, features = ["muthashmax"] }
 libc = "0.2"
 ringbuf = "0.2.6"

--- a/rust-grates/mtls-grate/Cargo.toml
+++ b/rust-grates/mtls-grate/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 grate-rs = { git = "https://github.com/Lind-Project/lind-wasm-example-grates", branch = "main", subdir = "lib/grate-rs" }
-fdtables = { git = "https://github.com/Lind-Project/lind-wasm", branch = "main", subdir = "src/fdtables" }
+fdtables = { git = "https://github.com/Lind-Project/lind-wasm", branch = "main", subdir = "src/fdtables", default-features = false, features = ["muthashmax"] }
 rustls = { version = "0.23", default-features = false, features = ["std", "tls12"] }
 rustls-rustcrypto = "0.0.2-alpha"
 rustls-pemfile = "2.1"

--- a/rust-grates/net-routing-clamp/Cargo.toml
+++ b/rust-grates/net-routing-clamp/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2024"
 
 [dependencies]
 grate-rs = { git = "https://github.com/Lind-Project/lind-wasm-example-grates", branch = "main", subdir = "lib/grate-rs" }
-fdtables = { git = "https://github.com/Lind-Project/lind-wasm", branch = "main", subdir = "src/fdtables" }
+fdtables = { git = "https://github.com/Lind-Project/lind-wasm", branch = "main", subdir = "src/fdtables", default-features = false, features = ["muthashmax"] }
 libc = "0.2"

--- a/rust-grates/resource-grate/Cargo.toml
+++ b/rust-grates/resource-grate/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2024"
 
 [dependencies]
 grate-rs = { git = "https://github.com/Lind-Project/lind-wasm-example-grates", branch = "main", subdir = "lib/grate-rs" }
-fdtables = { git = "https://github.com/Lind-Project/lind-wasm", branch = "main", subdir = "src/fdtables" }
+fdtables = { git = "https://github.com/Lind-Project/lind-wasm", branch = "main", subdir = "src/fdtables", default-features = false, features = ["muthashmax"] }
 libc = "0.2"

--- a/rust-grates/write-filter-grate/Cargo.toml
+++ b/rust-grates/write-filter-grate/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2024"
 
 [dependencies]
 grate-rs = { git = "https://github.com/Lind-Project/lind-wasm-example-grates", branch = "main", subdir = "lib/grate-rs" }
-fdtables = { git = "https://github.com/Lind-Project/lind-wasm", branch = "main", subdir = "src/fdtables" }
+fdtables = { git = "https://github.com/Lind-Project/lind-wasm", branch = "main", subdir = "src/fdtables", default-features = false, features = ["muthashmax"] }
 libc = "0.2"


### PR DESCRIPTION
## Summary

- All 9 Rust grates that depend on `fdtables` now opt into the `muthashmax` impl via Cargo features instead of taking the default (`dashmaparray`).
- One-line change per grate: `default-features = false, features = ["muthashmax"]`.

## Motivation

The historical `fdtables` default (`dashmaparray`) pulls in `dashmap → parking_lot → parking_lot_core`. On `wasm32`, `parking_lot_core`'s thread-parker is a stub that panics with:

```
thread '<unnamed>' (0xDEADBEEFDEADBEEF) panicked at parking_lot_core-0.9.12/src/thread_parker/wasm.rs:26
Parking not supported on this platform
```

This fires the moment `parking_lot`'s internal spinlock fails to acquire on the first try and falls back to actual thread parking. Under low contention you don't see it; under load you do. The IPC grate has been hitting it whenever multiple Lind runtime threads contend on fdtables shards (each `read`/`write`/`close` goes through `lookup_ipc_fd` → `translate_virtual_fd` → dashmap shard lock).

`muthashmax` uses `std::sync::Mutex<HashMap>` instead. No `parking_lot`, no panic.

## Caveats

- The `WASM threading issues` notes still apply — `std::sync::Mutex` doesn't synchronize across Lind runtime threads either. Symptom moves from a clean abort to occasional stale reads / data-level inconsistency. We trade a known panic for a known race.
- `muthashmax` is a single global `Mutex<HashMap>` rather than a sharded map. Throughput on fdtables-heavy hot paths (notably IPC's `read`/`write`/`close`) drops.
- Only affects Rust grates. C grates don't link `fdtables`.

## Depends on

[Lind-Project/lind-wasm#1159](https://github.com/Lind-Project/lind-wasm/pull/1159) — introduces the `[features]` block in `fdtables/Cargo.toml`. Without that PR landed, `default-features = false, features = ["muthashmax"]` is a no-op (no such feature exists).

## Test plan

- [ ] Lind-Project/lind-wasm#1159 has merged.
- [ ] `make all` (release profile) builds every Rust grate clean.
- [ ] Run the IPC grate under PostgreSQL load — confirm the "Parking not supported" panic is gone.
- [ ] Spot-check a couple of other grates (mtls, imfs) still build and pass their existing tests.
