### PR TITLE
ipc-grate: signal-aware nap in IPC wait loops via libc::nanosleep EINTR

### DIFF
--- a/rust-grates/ipc-grate/src/handlers.rs
+++ b/rust-grates/ipc-grate/src/handlers.rs
@@ -541,11 +541,47 @@ fn reclassify_ipc_pollfds(
     ready
 }
 
+/// EINTR in negative-errno form.
+const EINTR_NEG: i32 = -4;
+
+/// Sleep ~1ms in a way that's interruptible by signals queued for the
+/// calling user cage.  Returns `true` if the sleep was interrupted by
+/// a signal (caller should bail with EINTR so the cage's signal
+/// handler can run on the way out).
+///
+/// Mechanism: `libc::nanosleep` forwards to RawPOSIX's
+/// `nanosleep_time64_syscall` which calls the host's `clock_nanosleep`.
+/// `cage::signal::lind_send_signal` interrupts blocking host syscalls
+/// on the user cage's main thread by sending SIGUSR2 via `tkill`; the
+/// no-op handler causes `clock_nanosleep` to return -EINTR.  Since
+/// the grate is invoked on the user cage's main thread (the thread
+/// that issued the original syscall), *our* nanosleep is the target —
+/// no extra primitive needed.
+///
+/// Without this, the grate's IPC wait loops are signal-deaf for the
+/// entire timeout: while we spin, the cage is parked in our handler
+/// and its own user-code path that would observe the epoch flip can't
+/// run.  postgres' WaitLatch + SetLatch self-pipe pattern wedges as a
+/// direct result (postmaster hangs on ProcSignalBarrier waiting for a
+/// SIGUSR1 handler that never gets to run).
+fn ipc_wait_nap_signal_aware() -> bool {
+    unsafe {
+        let ts = libc::timespec { tv_sec: 0, tv_nsec: 1_000_000 };
+        // For a valid timespec the only error nanosleep can return is
+        // EINTR, so a negative return is conclusive.
+        libc::nanosleep(&ts, std::ptr::null_mut()) < 0
+    }
+}
+
 /// Local poll-loop for IPC-only poll/ppoll calls (i.e. no kernel fds).
 /// Sleeps in 1ms chunks, re-classifying IPC entries each iteration,
-/// until either a fd becomes ready or `timeout_ms` elapses.  Negative
-/// `timeout_ms` blocks forever (matches poll(2) semantics).  Returns
-/// the count of ready IPC entries (0 on timeout).
+/// until either a fd becomes ready, the calling cage has a signal
+/// pending, or `timeout_ms` elapses.  Negative `timeout_ms` blocks
+/// forever (matches poll(2) semantics).  Returns:
+///   > 0  number of ready IPC entries
+///   0    timeout
+///   -EINTR  cage has a signal pending — handler should return so the
+///           cage's signal handler can run on the way out
 fn ipc_only_poll_wait(
     cage_id: u64,
     pollfds: &[PollFd],
@@ -565,9 +601,8 @@ fn ipc_only_poll_wait(
                 return 0;
             }
         }
-        unsafe {
-            let ts = libc::timespec { tv_sec: 0, tv_nsec: 1_000_000 };
-            libc::nanosleep(&ts, std::ptr::null_mut());
+        if ipc_wait_nap_signal_aware() {
+            return EINTR_NEG;
         }
     }
 }
@@ -911,10 +946,8 @@ pub extern "C" fn select_handler(
                 if let Some(timeout) = timeout_ns {
                     if start.elapsed().as_nanos() >= timeout { break; }
                 }
-                // Sleep briefly between checks so we don't pin a CPU.
-                unsafe {
-                    let ts = libc::timespec { tv_sec: 0, tv_nsec: 1_000_000 };
-                    libc::nanosleep(&ts, std::ptr::null_mut());
+                if ipc_wait_nap_signal_aware() {
+                    return EINTR_NEG;
                 }
             }
         }
@@ -2215,7 +2248,9 @@ fn accept_ipc_inner(
             return -11; // EAGAIN
         }
 
-        std::thread::yield_now();
+        if ipc_wait_nap_signal_aware() {
+            return EINTR_NEG;
+        }
     }
 }
 


### PR DESCRIPTION
The IPC-only wait loops (poll/ppoll, select, accept_ipc_inner) spin the calling cage's main thread inside the grate's handler.  While that thread is parked, signals queued for the cage (postgres' SetLatch / SIGUSR1, etc.) can't reach their handler — the cage is signal-deaf for the entire timeout and postmaster startup wedges on ProcSignalBarrier.

Replace the unguarded nanosleep between iterations with one whose return value is checked.  When `cage::signal::lind_send_signal` fires, it sends SIGUSR2 via tkill to the user cage's main thread to interrupt blocking host syscalls.  Since the grate is invoked on that same thread, *our* `clock_nanosleep` (via RawPOSIX nanosleep_time64_syscall) is the syscall that gets interrupted.  A negative return means EINTR — propagate -EINTR up so the cage's signal handler runs on the way out.

No new runtime primitive needed: the existing signal-delivery path already targets the right thread.  (Initial draft assumed we'd need a wasmtime import for `signal_check_trigger`; that's only true if we wanted to *poll* signal state, which we don't — getting EINTR on the sleep is enough.)

Wired into:
- ipc_only_poll_wait (poll/ppoll)
- select_handler IPC-only wait
- accept_ipc_inner blocking accept