### PR TITLE
ipc-grate: shrink wait sleep to ~1µs and extend signal-awareness to P…

### DIFF
--- a/rust-grates/ipc-grate/src/handlers.rs
+++ b/rust-grates/ipc-grate/src/handlers.rs
@@ -566,7 +566,11 @@ const EINTR_NEG: i32 = -4;
 /// SIGUSR1 handler that never gets to run).
 fn ipc_wait_nap_signal_aware() -> bool {
     unsafe {
-        let ts = libc::timespec { tv_sec: 0, tv_nsec: 1_000_000 };
+        // Request 1µs.  The Linux kernel rounds up to its timer
+        // granularity (~50µs) regardless, so going smaller is a
+        // no-op.  Going larger (e.g. 1ms) hurts throughput on
+        // pipe-style waits without improving signal latency.
+        let ts = libc::timespec { tv_sec: 0, tv_nsec: 1_000 };
         // For a valid timespec the only error nanosleep can return is
         // EINTR, so a negative return is conclusive.
         libc::nanosleep(&ts, std::ptr::null_mut()) < 0

--- a/rust-grates/ipc-grate/src/pipe.rs
+++ b/rust-grates/ipc-grate/src/pipe.rs
@@ -16,7 +16,13 @@
 //!
 //! # Blocking
 //!
-//! Spin-loop with `thread::yield_now()`.
+//! Sleep in short (~1µs requested → ~50µs kernel-timer-rounded) chunks
+//! via `libc::nanosleep`, which forwards to the host's `clock_nanosleep`.
+//! `lind_send_signal` interrupts blocking host syscalls on the user
+//! cage's main thread by sending SIGUSR2 via `tkill`; since the grate
+//! runs on that thread, our `nanosleep` is the syscall that gets
+//! interrupted.  A negative return means EINTR — the read/write loop
+//! bails so the cage's signal handler can run.
 //!
 //! # Capacity
 //!
@@ -27,6 +33,18 @@ use std::cell::UnsafeCell;
 
 use ringbuf::RingBuffer;
 use ringbuf::{Consumer, Producer};
+
+/// Sleep ~50µs (1µs requested, kernel rounds up to its timer
+/// granularity) in a way that's interruptible by signals queued for
+/// the calling user cage.  Returns `true` if the sleep was
+/// interrupted; caller should propagate -EINTR so the cage's signal
+/// handler runs before the syscall is retried.
+fn nap_signal_aware() -> bool {
+    unsafe {
+        let ts = libc::timespec { tv_sec: 0, tv_nsec: 1_000 };
+        libc::nanosleep(&ts, std::ptr::null_mut()) < 0
+    }
+}
 
 /// Default pipe capacity in bytes (64 KB, matching Linux and safeposix-rust).
 pub const PIPE_CAPACITY: usize = 65536;
@@ -68,12 +86,13 @@ impl PipeBuffer {
         }
     }
 
-    /// Read from the pipe. Blocks (spins with yield) until data is available
-    /// or EOF is reached.
+    /// Read from the pipe.  Blocks (~50µs nanosleep chunks) until data
+    /// is available, EOF is reached, or a signal is delivered.
     ///
     /// Returns:
     ///   > 0: number of bytes read
     ///   0: EOF (all write ends closed and buffer drained)
+    ///   -4: EINTR (signal queued for the calling cage)
     ///   -11: EAGAIN (nonblocking mode, no data available)
     pub fn read(&self, dst: &mut [u8], count: usize, nonblocking: bool) -> i32 {
         let read_count = count.min(dst.len());
@@ -95,18 +114,26 @@ impl PipeBuffer {
                 return -11; // EAGAIN
             }
 
-            // Yield to let the writer run.
-            std::thread::yield_now();
+            // Sleep a short signal-interruptible chunk before retry.
+            // Without signal-awareness here, postgres' SetLatch /
+            // SIGTERM during a blocking pipe read goes unobserved.
+            if nap_signal_aware() {
+                return -4; // EINTR
+            }
         }
     }
 
-    /// Write to the pipe. Blocks (spins with yield) until space is available
-    /// or all read ends close.
+    /// Write to the pipe.  Blocks (~50µs nanosleep chunks) until space
+    /// is available, all read ends close, or a signal is delivered.
     ///
     /// Returns:
-    ///   > 0: number of bytes written
+    ///   > 0: number of bytes written (full count, or partial on signal /
+    ///        nonblocking)
+    ///   -4: EINTR (signal arrived before any bytes were written; if
+    ///       some bytes were already written we return the short count
+    ///       per POSIX write(2) semantics)
+    ///   -11: EAGAIN (nonblocking mode, pipe full and nothing written)
     ///   -32: EPIPE (all read ends closed — broken pipe)
-    ///   -11: EAGAIN (nonblocking mode, pipe full)
     pub fn write(&self, src: &[u8], count: usize, nonblocking: bool) -> i32 {
         if self.read_refs.load(Ordering::Acquire) == 0 {
             return -32; // EPIPE
@@ -139,7 +166,13 @@ impl PipeBuffer {
                 return -11; // EAGAIN
             }
 
-            std::thread::yield_now();
+            // Signal-aware sleep — see read() above for rationale.
+            if nap_signal_aware() {
+                if total_written > 0 {
+                    return total_written as i32;
+                }
+                return -4; // EINTR
+            }
         }
 
         total_written as i32


### PR DESCRIPTION
…ipeBuffer

Two related tweaks:

- All wait-loop nanosleeps drop from 1ms to 1µs (kernel rounds up to its timer granularity, ~50µs in practice).  1ms was severely overshooting on data-flow paths; 1µs is the smallest value that still produces a real sleep on the host clock.

- PipeBuffer::read / PipeBuffer::write replace `std::thread::yield_now()` with the same signal-aware nanosleep helper used in the handler wait loops.  `yield_now` isn't a host syscall in wasm32-wasip1 so it can't be interrupted by lind_send_signal's SIGUSR2 — meaning a blocked pipe read/write was signal-deaf in exactly the same way the poll/select/accept loops were before.

PipeBuffer::write now returns the partial-byte count if a signal arrives mid-write, falling back to -EINTR when nothing was written — matches POSIX write(2) semantics.  Read returns -EINTR straightforwardly.