### PR TITLE
chroot-grate: use Strncpy mode in read_path_from_cage to avoid 4 KB o…

### DIFF
--- a/rust-grates/chroot-grate/src/paths.rs
+++ b/rust-grates/chroot-grate/src/paths.rs
@@ -123,8 +123,13 @@ pub fn chroot_path(path: &str, cageid: u64) -> String {
 
 /// Read a NUL-terminated C string from a cage's memory and return it as UTF-8.
 ///
-/// Reads at most 4096 bytes; if no NUL terminator is found within that window,
-/// the whole buffer is returned.
+/// Uses `copytype=1` (Strncpy) so threei scans for the NUL byte in
+/// the source cage rather than blindly memcpy'ing 4096 bytes — a
+/// fixed-size read fails vmmap validation when the path buffer lives
+/// near the end of a mapped region (the [3i|copy] range invalid log
+/// shows exactly this: 4096-byte copies starting just inside a page
+/// that doesn't extend a full 4 KB).  Strncpy mode validates one byte
+/// at a time and copies up to and including the NUL.
 pub fn read_path_from_cage(ptr: u64, src_cage: u64) -> Option<String> {
     let thiscage = getcageid();
     let mut buf = vec![0u8; 4096];
@@ -137,7 +142,7 @@ pub fn read_path_from_cage(ptr: u64, src_cage: u64) -> Option<String> {
         buf.as_mut_ptr() as u64,
         thiscage,
         buf.len() as u64,
-        0,
+        /* copytype = */ 1, // Strncpy: stop at NUL, byte-by-byte validate
     ) {
         Ok(_) => {
             let len = buf.iter().position(|&b| b == 0).unwrap_or(buf.len());


### PR DESCRIPTION
…ver-read

read_path_from_cage was calling copy_data_between_cages with copytype=0 (RawMemcpy) and len=4096 — fine when the path buffer sits well inside a mapped region, but it fails vmmap validation whenever the buffer is near the end of one (path lives at e.g. heap_addr+0x2005 in a region that doesn't extend a full 4 KB).  Result: every chroot-grate test that hit a path-rewriting syscall on a buffer near a page boundary got "[3i|copy] range invalid: addr=…, len=4096, what=source" and the caller fell back to EPERM.  Affected tests in baseline included execve_shebang, fchdir, readv_writev_test, rename, mknod, plus the EPERM-cascade output mismatches in readlink / unlinkat / unlink / link.

Switch to copytype=1 (Strncpy): threei walks bytes one at a time using check_addr_read, finds the NUL, and copies exactly that many bytes — no validation failure on a short final page.  Same scan semantics that glibc string syscall wrappers already rely on.

Other copy_data_between_cages sites in this grate use known fixed lengths (sockaddr addrlen, the 4-byte addrlen-u32, etc.) and are correct as-is.