### PR TITLE
chroot-grate: propagate kernel -errno instead of collapsing to -1/EPERM

### DIFF
--- a/rust-grates/chroot-grate/src/main.rs
+++ b/rust-grates/chroot-grate/src/main.rs
@@ -9,7 +9,7 @@ use grate_rs::constants::{
     SYS_STATFS, SYS_TRUNCATE, SYS_UNLINK, SYS_UNLINKAT, SYS_XSTAT,
 };
 use grate_rs::ffi::stat;
-use grate_rs::{GrateBuilder, copy_data_between_cages, getcageid, make_threei_call};
+use grate_rs::{GrateBuilder, GrateError, copy_data_between_cages, getcageid, make_threei_call};
 use std::collections::HashMap;
 use std::ffi::CString;
 use std::ffi::c_char;
@@ -98,6 +98,11 @@ fn call_with_rewrites(
         0,
     ) {
         Ok(ret) => ret,
+        // Propagate the kernel's actual -errno (e.g. -ENOENT, -EEXIST,
+        // -EISDIR) instead of collapsing every failure to -1 / EPERM.
+        // glibc's MAKE_LEGACY_SYSCALL with TRANSLATE_ERRNO_ON converts
+        // negative values in [-MAX_ERRNO, -1] into errno + return -1.
+        Err(GrateError::MakeSyscallError(n)) => n,
         Err(_) => -1,
     }
 }
@@ -234,6 +239,7 @@ extern "C" fn readlink_handler(
         0,
     ) {
         Ok(r) => r,
+        Err(GrateError::MakeSyscallError(n)) => return n,
         Err(_) => return -1,
     };
 
@@ -316,6 +322,7 @@ extern "C" fn readlinkat_handler(
         0,
     ) {
         Ok(r) => r,
+        Err(GrateError::MakeSyscallError(n)) => return n,
         Err(_) => return -1,
     };
 
@@ -373,6 +380,7 @@ extern "C" fn fork_handler(
         0,
     ) {
         Ok(r) => r,
+        Err(GrateError::MakeSyscallError(n)) => return n,
         Err(_) => return -1,
     };
 
@@ -433,6 +441,7 @@ extern "C" fn execve_handler(
         0,
     ) {
         Ok(r) => return r,
+        Err(GrateError::MakeSyscallError(n)) => return n,
         Err(_) => return -1,
     }
 }

--- a/rust-grates/chroot-grate/src/sockets.rs
+++ b/rust-grates/chroot-grate/src/sockets.rs
@@ -89,6 +89,9 @@ macro_rules! socket_translate_handler {
                     0,
                 ) {
                     Ok(ret) => ret,
+                    // Propagate the actual -errno from the kernel
+                    // instead of collapsing to -1 / EPERM.
+                    Err(::grate_rs::GrateError::MakeSyscallError(n)) => n,
                     Err(_) => -1,
                 }
             }


### PR DESCRIPTION
Every site that called `make_threei_call` was matching `Err(_) => -1`, which discarded the actual -errno from the kernel and returned -1. glibc's MAKE_LEGACY_SYSCALL with TRANSLATE_ERRNO_ON treats -1 as errno=1 = EPERM.  Result: every kernel-side error (ENOENT for missing files, EEXIST for already-existing files, EISDIR for directories, ENOTDIR for non-dirs, etc.) was reported as "Operation not permitted".

Tests that explicitly assert errno values were the obvious victims — unlink expecting ENOENT, link expecting EEXIST, readlink/unlinkat with their kernel-error cases, readdir_basic's mkdir.  But silently turning real errnos into EPERM is a footgun for any caller that branches on errno (postgres pg_hba lookup, glibc fallback paths, ...).

The IPC grate's `forward_syscall` already had the right pattern; copy it to chroot-grate's call_with_rewrites and the in-line make_threei_call sites in readlink/readlinkat/etc. handlers, and the sockets.rs no-rewrite branch:

    Err(GrateError::MakeSyscallError(n)) => n,
    Err(_) => -1,

CString::new failures still collapse to -1; that path is genuinely "can't even encode" so EPERM is a fine sentinel there.