### PR TITLE
chroot-grate: propagate negative syscall returns through socket_untra…

### DIFF
--- a/rust-grates/chroot-grate/src/sockets.rs
+++ b/rust-grates/chroot-grate/src/sockets.rs
@@ -128,6 +128,15 @@ macro_rules! socket_untranslate_handler {
             let cages = [arg1cage, arg2cage, arg3cage, arg4cage, arg5cage, arg6cage];
 
             // Call the real syscall.
+            //
+            // grate-rs's `make_threei_call` maps every negative return into
+            // `Err(MakeSyscallError(n))` — including normal blocking-syscall
+            // errnos like -EAGAIN, -EINTR, -ECONNREFUSED.  We have to
+            // propagate those to the cage as-is; collapsing them to -1
+            // would surface as EPERM via glibc's errno translation and
+            // break recvfrom/accept/getsockname/getpeername on any
+            // transient failure.  Only treat dispatch-layer errors
+            // (e.g. ELINDAPIABORTED) as a hard EIO.
             let ret = match make_threei_call(
                 $syscall_const as u32,
                 0,
@@ -148,7 +157,8 @@ macro_rules! socket_untranslate_handler {
                 0,
             ) {
                 Ok(r) => r,
-                Err(_) => return -1,
+                Err(::grate_rs::GrateError::MakeSyscallError(n)) => n,
+                Err(_) => return -(::libc::EIO as i32),
             };
 
             // On success, untranslate the returned peer sockaddr (strip chroot from AF_UNIX).


### PR DESCRIPTION
…nslate_handler

grate-rs maps every negative return from make_threei_call into Err(MakeSyscallError(n)).  That includes normal blocking-syscall errnos like -EAGAIN, -EINTR, -ECONNREFUSED.  The
socket_untranslate_handler macro was collapsing all errors to -1, which glibc's TRANSLATE_ERRNO_ON converts to errno=1=EPERM — so a non-blocking recvfrom returning -EAGAIN would surface to the cage as 'Operation not permitted'.

Match on MakeSyscallError(n) and return n as the syscall result, the same way socket_translate_handler already does.  Reserve the catch-all Err arm for dispatch-layer failures (e.g. ELINDAPIABORTED) and map those to -EIO instead of -1, since EPERM is a misleading fallback for anything that isn't actually a permission error.