### PR TITLE
ipc-grate: restore 1ms nanosleep in signal-aware nap helpers

### DIFF
--- a/rust-grates/ipc-grate/src/handlers.rs
+++ b/rust-grates/ipc-grate/src/handlers.rs
@@ -555,11 +555,15 @@ const EINTR_NEG: i32 = -4;
 /// SIGUSR1 handler that never gets to run).
 fn ipc_wait_nap_signal_aware() -> bool {
     unsafe {
-        // Request 1µs.  The Linux kernel rounds up to its timer
-        // granularity (~50µs) regardless, so going smaller is a
-        // no-op.  Going larger (e.g. 1ms) hurts throughput on
-        // pipe-style waits without improving signal latency.
-        let ts = libc::timespec { tv_sec: 0, tv_nsec: 1_000 };
+        // 1ms — proven-good value from 236c62b.  Was shrunk to 1µs on
+        // the theory that the kernel rounds up to timer granularity
+        // (~50µs) anyway, so smaller is free.  In practice that broke
+        // SetLatch / self-pipe-trick wakeups (postgres
+        // PM_STARTUP→PM_RUN handoff, `self_pipe_signal.c`): the cage
+        // got EINTR but its signal-handler dispatch wasn't given
+        // enough scheduler time to run between iterations.  Going
+        // back to 1ms restores reliable signal delivery.
+        let ts = libc::timespec { tv_sec: 0, tv_nsec: 1_000_000 };
         // For a valid timespec the only error nanosleep can return is
         // EINTR, so a negative return is conclusive.
         libc::nanosleep(&ts, std::ptr::null_mut()) < 0

--- a/rust-grates/ipc-grate/src/pipe.rs
+++ b/rust-grates/ipc-grate/src/pipe.rs
@@ -36,14 +36,22 @@ use ringbuf::{Consumer, Producer};
 
 use grate_rs::copy_data_between_cages;
 
-/// Sleep ~50µs (1µs requested, kernel rounds up to its timer
-/// granularity) in a way that's interruptible by signals queued for
-/// the calling user cage.  Returns `true` if the sleep was
-/// interrupted; caller should propagate -EINTR so the cage's signal
-/// handler runs before the syscall is retried.
+/// Sleep 1ms in a way that's interruptible by signals queued for the
+/// calling user cage.  Returns `true` if the sleep was interrupted;
+/// caller should propagate -EINTR so the cage's signal handler runs
+/// before the syscall is retried.
+///
+/// History: this used to be 1µs on the theory that the kernel rounds
+/// up to its timer granularity (~50µs) anyway, so smaller is free.
+/// In practice that broke the SetLatch / self-pipe-trick pattern
+/// (postgres PM_STARTUP→PM_RUN handoff, `self_pipe_signal.c`):
+/// signals delivered during the wait got interrupted but the cage's
+/// signal-handler dispatch wasn't given enough scheduler time to run
+/// between iterations.  The proven-good value is 1ms — it's also what
+/// the original signal-aware-nap commit (236c62b) used.
 fn nap_signal_aware() -> bool {
     unsafe {
-        let ts = libc::timespec { tv_sec: 0, tv_nsec: 1_000 };
+        let ts = libc::timespec { tv_sec: 0, tv_nsec: 1_000_000 };
         libc::nanosleep(&ts, std::ptr::null_mut()) < 0
     }
 }


### PR DESCRIPTION
Both nap_signal_aware (pipe.rs) and ipc_wait_nap_signal_aware (handlers.rs) were shrunk from 1ms to 1µs by 46797eb on the theory that the kernel rounds up to timer granularity (~50µs) anyway, so smaller is free.

In practice that broke the self-pipe-trick / SetLatch pattern that postgres uses for PM_STARTUP→PM_RUN handoff and that `self_pipe_signal.c` exercises directly.  At 1µs (and 10µs and 50µs) the signal-handler dispatch on the cage side doesn't reliably get scheduler time between iterations of our wait loop, so SIGUSR1 arrives but the handler never runs to write the wakeup byte.  At 1ms it does.

Restore 1ms in both helpers, the value used by the original signal-aware-nap commit (236c62b) which passed self_pipe_signal.c.