### PR TITLE
fs-routing-clamp: Propagate exit code from child when exiting.

### DIFF
--- a/rust-grates/fs-routing-clamp/src/main.rs
+++ b/rust-grates/fs-routing-clamp/src/main.rs
@@ -190,15 +190,10 @@ fn main() {
     // Signal the child to proceed.
     unsafe { sem_post(sem) };
 
-    // Wait for all children.
-    loop {
-        let mut status: i32 = 0;
-        let ret = unsafe { waitpid(-1, &mut status as *mut i32, 0) };
-        if ret <= 0 {
-            break;
-        }
-        log!("child {} exited with status {}", ret, status);
-    }
+    // Wait for child to exit.
+    let mut status: i32 = 0;
+    let ret = unsafe { waitpid(-1, &mut status as *mut i32, 0) };
+    log!("child {} exited with status {}", ret, status);
 
     // Cleanup.
     unsafe {
@@ -206,6 +201,7 @@ fn main() {
         munmap(sem as *mut c_void, std::mem::size_of::<sem_t>());
     }
 
-    log!("exiting");
-    std::process::exit(0);
+    let exit_code = (status >> 8) & 0xff;
+    log!("exiting with {}", exit_code);
+    std::process::exit(exit_code);
 }


### PR DESCRIPTION
Replaces the blanket `exit(0)` with `exit((status >> 8) & 0xff)`