### PR TITLE
IMFS Postgres Fixes: 1. Add fsync_handler 2. Remove use of libc:: constants for file types

### DIFF
--- a/lib/grate-rs/src/constants/fs.rs
+++ b/lib/grate-rs/src/constants/fs.rs
@@ -14,6 +14,15 @@ pub const O_TRUNC: i32 = 0o1000;
 pub const O_APPEND: i32 = 0o2000;
 pub const O_DIRECTORY: i32 = 0o200000;
 
+pub const DT_UNKNOWN: u8 = 0;
+pub const DT_FIFO: u8 = 1;
+pub const DT_CHR: u8 = 2;
+pub const DT_DIR: u8 = 4;
+pub const DT_BLK: u8 = 6;
+pub const DT_REG: u8 = 8;
+pub const DT_LNK: u8 = 10;
+pub const DT_SOCK: u8 = 12;
+
 pub const SEEK_SET: i32 = 0;
 pub const SEEK_CUR: i32 = 1;
 pub const SEEK_END: i32 = 2;

--- a/rust-grates/imfs-grate/src/handlers.rs
+++ b/rust-grates/imfs-grate/src/handlers.rs
@@ -1177,6 +1177,24 @@ pub extern "C" fn mknod_handler(
     -38 // ENOSYS
 }
 
+pub extern "C" fn fsync_handler(
+    _cageid: u64,
+    _arg1: u64,
+    _arg1cage: u64,
+    _arg2: u64,
+    _arg2cage: u64,
+    _arg3: u64,
+    _arg3cage: u64,
+    _arg4: u64,
+    _arg4cage: u64,
+    _arg5: u64,
+    _arg5cage: u64,
+    _arg6: u64,
+    _arg6cage: u64,
+) -> i32 {
+    0
+}
+
 // =====================================================================
 //  fork (syscall 57)
 //

--- a/rust-grates/imfs-grate/src/imfs/mod.rs
+++ b/rust-grates/imfs-grate/src/imfs/mod.rs
@@ -120,10 +120,10 @@ impl ImfsState {
         }
 
         match self.nodes[idx].node_type {
-            NodeType::Dir => libc::DT_DIR,
-            NodeType::Reg => libc::DT_REG,
-            NodeType::Lnk => libc::DT_LNK,
-            _ => libc::DT_UNKNOWN,
+            NodeType::Dir => DT_DIR,
+            NodeType::Reg => DT_REG,
+            NodeType::Lnk => DT_LNK,
+            _ => DT_UNKNOWN,
         }
     }
 

--- a/rust-grates/imfs-grate/src/main.rs
+++ b/rust-grates/imfs-grate/src/main.rs
@@ -91,7 +91,7 @@ fn main() {
         .register(SYS_FCHMOD, handlers::enosys_handler)
         .register(SYS_READV, handlers::readv_handler)
         .register(SYS_WRITEV, handlers::writev_handler)
-        .register(SYS_FSYNC, handlers::enosys_handler)
+        .register(SYS_FSYNC, handlers::fsync_handler)
         .register(SYS_FDATASYNC, handlers::enosys_handler)
         .register(SYS_STATFS, handlers::enosys_handler)
         .register(SYS_FSTATFS, handlers::enosys_handler)


### PR DESCRIPTION
readdir/getdents was reporting wrong file type because it was accidentally using libc:: (WASI) constants. Added those to grate_rs::constants::fs instead. 

fsync_handler: since we do not "flush" to disk, simply returns 0 but this is needed for compatibility.