### PR TITLE
Add mmap fd handling in fs-routing

### DIFF
--- a/lib/grate-rs/src/constants/mman.rs
+++ b/lib/grate-rs/src/constants/mman.rs
@@ -10,4 +10,3 @@ pub const PROT_WRITE: i32 = 0x2; // pages may be written
 pub const MAP_SHARED: i32 = 0x01; // share mapping with other processes
 pub const MAP_ANON: i32 = 0x20; // mapping is not backed by a file (same as MAP_ANONYMOUS)
 pub const MAP_FAILED: *mut core::ffi::c_void = (-1isize) as *mut core::ffi::c_void;
-pub const MAP_ANONYMOUS: u64 = 0x20;

--- a/lib/grate-rs/src/constants/mman.rs
+++ b/lib/grate-rs/src/constants/mman.rs
@@ -10,3 +10,4 @@ pub const PROT_WRITE: i32 = 0x2; // pages may be written
 pub const MAP_SHARED: i32 = 0x01; // share mapping with other processes
 pub const MAP_ANON: i32 = 0x20; // mapping is not backed by a file (same as MAP_ANONYMOUS)
 pub const MAP_FAILED: *mut core::ffi::c_void = (-1isize) as *mut core::ffi::c_void;
+pub const MAP_ANONYMOUS: u64 = 0x20;

--- a/lib/grate-rs/src/constants/syscall_numbers.rs
+++ b/lib/grate-rs/src/constants/syscall_numbers.rs
@@ -110,6 +110,7 @@ pub const SYS_SYMLINKAT: u64 = 266;
 pub const SYS_READLINKAT: u64 = 267;
 pub const SYS_PPOLL: u64 = 271;
 pub const SYS_SYNC_FILE_RANGE: u64 = 277;
+pub const SYS_UTIMENSAT: u64 = 280;
 pub const SYS_ACCEPT4: u64 = 288;
 pub const SYS_EPOLL_CREATE1: u64 = 291;
 pub const SYS_DUP3: u64 = 292;

--- a/rust-grates/fs-routing-clamp/src/handlers/ns_handlers.rs
+++ b/rust-grates/fs-routing-clamp/src/handlers/ns_handlers.rs
@@ -1,7 +1,7 @@
 use crate::helpers;
 use grate_rs::{SyscallHandler, constants::*, copy_data_between_cages, getcageid, is_thread_clone};
 use grate_rs::constants::fs::{F_DUPFD, F_DUPFD_CLOEXEC};
-use grate_rs::constants::mman::MAP_ANONYMOUS;
+use grate_rs::constants::mman::MAP_ANON;
 // =====================================================================
 //  PATH-BASED SYSCALL HANDLERS
 //
@@ -328,7 +328,7 @@ pub extern "C" fn ns_mmap_handler(
      * MAP_ANONYMOUS means fd is ignored.
      * Do not route based on fd in that case, because fd may be -1.
      */
-    let is_anonymous = (arg4 & MAP_ANONYMOUS) != 0;
+    let is_anonymous = (arg4 & MAP_ANON as u64) != 0;
 
     if !is_anonymous {
         let fd = arg5;
@@ -337,18 +337,63 @@ pub extern "C" fn ns_mmap_handler(
             .map(|e| e.perfdinfo != 0)
             .unwrap_or(false)
         {
-            match helpers::get_route(arg1cage, SYS_MMAP) {
+            let ret = match helpers::get_route(arg1cage, SYS_MMAP) {
                 Some(alt) => {
                     return helpers::do_syscall(arg1cage, alt, &args, &arg_cages);
                 }
                 None => {
                     return helpers::do_clamp_syscall(arg1cage, SYS_MMAP, &args, &arg_cages);
                 }
+            };
+            if ret >= 0 {
+                helpers::record_clamped_mmap(arg1cage, ret as u64, arg2);
             }
+            return ret;
         }
     }
 
     helpers::do_syscall(arg1cage, SYS_MMAP, &args, &arg_cages)
+}
+
+/// munmap (syscall 11): unmap memory.
+///
+/// munmap has no fd argument, so fd-based routing is impossible here.
+/// Instead, route if the addr/len overlaps a range previously returned by a
+/// clamped mmap. This lets clamped grates such as imfs decrement mmap_refs.
+pub extern "C" fn ns_munmap_handler(
+    _cageid: u64,
+    arg1: u64,      // addr
+    arg1cage: u64,
+    arg2: u64,      // length
+    arg2cage: u64,
+    arg3: u64,
+    arg3cage: u64,
+    arg4: u64,
+    arg4cage: u64,
+    arg5: u64,
+    arg5cage: u64,
+    arg6: u64,
+    arg6cage: u64,
+) -> i32 {
+    let args = [arg1, arg2, arg3, arg4, arg5, arg6];
+    let arg_cages = [arg1cage, arg2cage, arg3cage, arg4cage, arg5cage, arg6cage];
+
+    let is_clamped_mapping = helpers::is_clamped_mmap(arg1cage, arg1, arg2);
+
+    if is_clamped_mapping {
+        let ret = match helpers::get_route(arg1cage, SYS_MUNMAP) {
+            Some(alt) => helpers::do_syscall(arg1cage, alt, &args, &arg_cages),
+            None => helpers::do_clamp_syscall(arg1cage, SYS_MUNMAP, &args, &arg_cages),
+        };
+
+        if ret == 0 {
+            helpers::remove_clamped_mmap(arg1cage, arg1, arg2);
+        }
+
+        return ret;
+    }
+
+    helpers::do_syscall(arg1cage, SYS_MUNMAP, &args, &arg_cages)
 }
 
 pub extern "C" fn ns_fcntl_handler(

--- a/rust-grates/fs-routing-clamp/src/handlers/ns_handlers.rs
+++ b/rust-grates/fs-routing-clamp/src/handlers/ns_handlers.rs
@@ -338,12 +338,8 @@ pub extern "C" fn ns_mmap_handler(
             .unwrap_or(false)
         {
             let ret = match helpers::get_route(arg1cage, SYS_MMAP) {
-                Some(alt) => {
-                    return helpers::do_syscall(arg1cage, alt, &args, &arg_cages);
-                }
-                None => {
-                    return helpers::do_clamp_syscall(arg1cage, SYS_MMAP, &args, &arg_cages);
-                }
+                Some(alt) => helpers::do_syscall(arg1cage, alt, &args, &arg_cages),
+                None => helpers::do_clamp_syscall(arg1cage, SYS_MMAP, &args, &arg_cages),
             };
             if ret >= 0 {
                 helpers::record_clamped_mmap(arg1cage, ret as u64, arg2);

--- a/rust-grates/fs-routing-clamp/src/handlers/ns_handlers.rs
+++ b/rust-grates/fs-routing-clamp/src/handlers/ns_handlers.rs
@@ -1,6 +1,7 @@
 use crate::helpers;
 use grate_rs::{SyscallHandler, constants::*, copy_data_between_cages, getcageid, is_thread_clone};
 use grate_rs::constants::fs::{F_DUPFD, F_DUPFD_CLOEXEC};
+use grate_rs::constants::mman::MAP_ANONYMOUS;
 // =====================================================================
 //  PATH-BASED SYSCALL HANDLERS
 //
@@ -299,6 +300,59 @@ pub extern "C" fn ns_close_handler(
     let _ = fdtables::close_virtualfd(arg1cage, arg1);
 
     ret
+}
+
+/// mmap (syscall 9): map file or anonymous memory.
+///
+/// Routing decision is based on arg5, the file descriptor.
+/// For MAP_ANONYMOUS / MAP_ANON, fd is ignored and should not trigger fd-based routing.
+pub extern "C" fn ns_mmap_handler(
+    _cageid: u64,
+    arg1: u64,      // addr
+    arg1cage: u64,
+    arg2: u64,      // length
+    arg2cage: u64,
+    arg3: u64,      // prot
+    arg3cage: u64,
+    arg4: u64,      // flags
+    arg4cage: u64,
+    arg5: u64,      // fd
+    arg5cage: u64,
+    arg6: u64,      // offset
+    arg6cage: u64,
+) -> i32 {
+    let args = [arg1, arg2, arg3, arg4, arg5, arg6];
+    let arg_cages = [arg1cage, arg2cage, arg3cage, arg4cage, arg5cage, arg6cage];
+
+    /*
+     * MAP_ANONYMOUS means fd is ignored.
+     * Do not route based on fd in that case, because fd may be -1.
+     */
+    let is_anonymous = (arg4 & MAP_ANONYMOUS) != 0;
+
+    println!("ns_mmap_handler: is_anonymous={}, fd={}", is_anonymous, arg5);
+
+    if !is_anonymous {
+        let fd = arg5;
+
+        if fdtables::translate_virtual_fd(arg1cage, fd)
+            .map(|e| e.perfdinfo != 0)
+            .unwrap_or(false)
+        {
+            match helpers::get_route(arg1cage, SYS_MMAP) {
+                Some(alt) => {
+                    println!("ns_mmap_handler: fd {} is clamped, routing to alt {}.", fd, alt);
+                    return helpers::do_syscall(arg1cage, alt, &args, &arg_cages);
+                }
+                None => {
+                    println!("ns_mmap_handler: fd {} is clamped but no alt route, invoking clamp syscall", fd);
+                    return helpers::do_clamp_syscall(arg1cage, SYS_MMAP, &args, &arg_cages);
+                }
+            }
+        }
+    }
+
+    helpers::do_syscall(arg1cage, SYS_MMAP, &args, &arg_cages)
 }
 
 pub extern "C" fn ns_fcntl_handler(
@@ -605,6 +659,7 @@ pub fn get_ns_handler(syscall_nr: u64) -> Option<SyscallHandler> {
         SYS_FDATASYNC => Some(ns_fdatasync_handler),
         SYS_FSTATFS => Some(ns_fstatfs_handler),
         SYS_SYNC_FILE_RANGE => Some(ns_sync_file_range_handler),
+        SYS_MMAP => Some(ns_mmap_handler),
 
         // FD-based with fd-tracking side effects
         SYS_DUP => Some(ns_dup_handler),

--- a/rust-grates/fs-routing-clamp/src/handlers/ns_handlers.rs
+++ b/rust-grates/fs-routing-clamp/src/handlers/ns_handlers.rs
@@ -330,8 +330,6 @@ pub extern "C" fn ns_mmap_handler(
      */
     let is_anonymous = (arg4 & MAP_ANONYMOUS) != 0;
 
-    println!("ns_mmap_handler: is_anonymous={}, fd={}", is_anonymous, arg5);
-
     if !is_anonymous {
         let fd = arg5;
 
@@ -341,11 +339,9 @@ pub extern "C" fn ns_mmap_handler(
         {
             match helpers::get_route(arg1cage, SYS_MMAP) {
                 Some(alt) => {
-                    println!("ns_mmap_handler: fd {} is clamped, routing to alt {}.", fd, alt);
                     return helpers::do_syscall(arg1cage, alt, &args, &arg_cages);
                 }
                 None => {
-                    println!("ns_mmap_handler: fd {} is clamped but no alt route, invoking clamp syscall", fd);
                     return helpers::do_clamp_syscall(arg1cage, SYS_MMAP, &args, &arg_cages);
                 }
             }

--- a/rust-grates/fs-routing-clamp/src/helpers.rs
+++ b/rust-grates/fs-routing-clamp/src/helpers.rs
@@ -8,7 +8,7 @@
 
 use grate_rs::constants::*;
 use std::collections::HashMap;
-use std::sync::Mutex;
+use std::sync::{Mutex, OnceLock};
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use grate_rs::{GrateError, copy_data_between_cages, make_threei_call};
@@ -16,7 +16,7 @@ use grate_rs::{GrateError, copy_data_between_cages, make_threei_call};
 // These are all the calls that the fs-namespace grate cares about. All of the
 // following calls from the target must be routed through the grate regardless
 // of whether the clamp interposed on them.
-pub const FS_CALLS: [u64; 45] = [
+pub const FS_CALLS: [u64; 46] = [
     SYS_OPEN,
     SYS_OPENAT,
     SYS_XSTAT,
@@ -58,6 +58,7 @@ pub const FS_CALLS: [u64; 45] = [
     SYS_FDATASYNC,
     SYS_FSTATFS,
     SYS_SYNC_FILE_RANGE,
+    SYS_MMAP,
     // FD-based with fd-tracking side effects
     SYS_DUP,
     SYS_DUP2,
@@ -454,5 +455,100 @@ pub fn do_clamp_syscall(callingcage: u64, nr: u64, args: &[u64; 6], arg_cages: &
         Ok(ret) => ret,
         Err(GrateError::MakeSyscallError(ret)) => ret,
         _ => -1,
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct ClampedMmapRange {
+    start: u64,
+    end: u64,
+}
+
+static CLAMPED_MMAPS: OnceLock<Mutex<HashMap<u64, Vec<ClampedMmapRange>>>> = OnceLock::new();
+
+fn clamped_mmaps() -> &'static Mutex<HashMap<u64, Vec<ClampedMmapRange>>> {
+    CLAMPED_MMAPS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+pub fn record_clamped_mmap(cageid: u64, addr: u64, len: u64) {
+    if len == 0 {
+        return;
+    }
+
+    let Some(end) = addr.checked_add(len) else {
+        return;
+    };
+
+    let mut maps = clamped_mmaps().lock().unwrap();
+    maps.entry(cageid)
+        .or_default()
+        .push(ClampedMmapRange { start: addr, end });
+}
+
+pub fn is_clamped_mmap(cageid: u64, addr: u64, len: u64) -> bool {
+    if len == 0 {
+        return false;
+    }
+
+    let Some(end) = addr.checked_add(len) else {
+        return false;
+    };
+
+    let maps = clamped_mmaps().lock().unwrap();
+
+    maps.get(&cageid)
+        .map(|ranges| {
+            ranges
+                .iter()
+                .any(|r| addr < r.end && end > r.start)
+        })
+        .unwrap_or(false)
+}
+
+pub fn remove_clamped_mmap(cageid: u64, addr: u64, len: u64) {
+    if len == 0 {
+        return;
+    }
+
+    let Some(end) = addr.checked_add(len) else {
+        return;
+    };
+
+    let mut maps = clamped_mmaps().lock().unwrap();
+
+    let Some(ranges) = maps.get_mut(&cageid) else {
+        return;
+    };
+
+    let mut new_ranges = Vec::with_capacity(ranges.len());
+
+    for r in ranges.drain(..) {
+        // No overlap.
+        if end <= r.start || addr >= r.end {
+            new_ranges.push(r);
+            continue;
+        }
+
+        // Left remainder.
+        if addr > r.start {
+            new_ranges.push(ClampedMmapRange {
+                start: r.start,
+                end: addr,
+            });
+        }
+
+        // Right remainder.
+        if end < r.end {
+            new_ranges.push(ClampedMmapRange {
+                start: end,
+                end: r.end,
+            });
+        }
+    }
+
+    *ranges = new_ranges;
+
+    if ranges.is_empty() {
+        maps.remove(&cageid);
     }
 }


### PR DESCRIPTION
Route mmap/munmap for clamped file mappings.

mmap now routes based on the fd unless MAP_ANON is set, since anonymous mmap
ignores fd and callers commonly pass -1 there. Successful clamped mmaps are
recorded by addr/len so munmap can later be routed by mapping address. This is
needed for clamped grates such as imfs to observe matching munmaps and maintain
RegMapped/mmap_refs bookkeeping correctly.