### PR TITLE
Remove default fd translation in fsrouting and add munmap handler

### DIFF
--- a/rust-grates/fs-routing-clamp/Cargo.toml
+++ b/rust-grates/fs-routing-clamp/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-grate-rs = { git = "https://github.com/Lind-Project/lind-wasm-example-grates", branch = "main", subdir = "lib/grate-rs" }
+grate-rs = { path = "../../lib/grate-rs" }
 fdtables = { git = "https://github.com/Lind-Project/lind-wasm", branch = "main", subdir = "src/fdtables", default-features = false, features = ["muthashmax"] }
 libc = "0.2"

--- a/rust-grates/fs-routing-clamp/src/handlers/clamped_lifecycle.rs
+++ b/rust-grates/fs-routing-clamp/src/handlers/clamped_lifecycle.rs
@@ -1,6 +1,6 @@
 use grate_rs::{
     SyscallHandler, constants::*, copy_data_between_cages, getcageid, is_thread_clone,
-    register_handler, register_default_fd_handlers_except,
+    register_handler,
 };
 
 use fdtables;
@@ -8,8 +8,6 @@ use fdtables;
 use crate::handlers::get_ns_handler;
 use crate::helpers::{self, FS_CALLS};
 use crate::log;
-
-use std::collections::HashSet;
 
 // =====================================================================
 //  1. LIFECYCLE HANDLERS
@@ -99,7 +97,7 @@ pub fn register_target_handlers(target_cage: u64) -> i32 {
             // ... Add to routing table.
             let _ = helpers::set_route(target_cage, fs_syscall, alt_nr);
         }
-        
+
         // The visible handler on the target cage always points at ns-grate.
         match register_handler(target_cage, fs_syscall, ns_cage, ns_handler.unwrap()) {
             Ok(_) => {}
@@ -107,18 +105,6 @@ pub fn register_target_handlers(target_cage: u64) -> i32 {
                 log!("failed to register ns handler: {:?}", e);
                 return -1;
             }
-        }
-    }
-
-    match register_default_fd_handlers_except(
-        target_cage,
-        ns_cage,
-        Some(FS_CALLS.into_iter().collect::<HashSet<u64>>()),
-    ) {
-        Ok(_) => {}
-        Err(e) => {
-            log!("failed to register default fd handlers: {:?}", e);
-            return -1;
         }
     }
 

--- a/rust-grates/fs-routing-clamp/src/handlers/ns_handlers.rs
+++ b/rust-grates/fs-routing-clamp/src/handlers/ns_handlers.rs
@@ -39,7 +39,14 @@ macro_rules! define_path_handler {
                 None => $sysno,
             };
 
-            helpers::do_syscall(arg1cage, nr, &args, &arg_cages)
+            let ret = helpers::do_syscall(arg1cage, nr, &args, &arg_cages);
+            // if $sysno == SYS_CHMOD {
+            //     let path = helpers::resolve_path_from_cage(arg2cage, arg1, arg1cage).unwrap();
+            //     println!("chmod {} {:o} -> {}", path, arg3, ret);
+            // }
+            let path = helpers::resolve_path_from_cage(arg2cage, arg1, arg1cage).unwrap_or_default();
+            println!("ns_{}: arg1 (path ptr) = {}, arg1cage = {}, ret = {}", stringify!($name), path, arg1cage, ret);
+            ret
         }
     };
 }
@@ -83,6 +90,8 @@ pub extern "C" fn ns_chdir_handler(
 ) -> i32 {
     let args = [arg1, arg2, arg3, arg4, arg5, arg6];
     let arg_cages = [arg1cage, arg2cage, arg3cage, arg4cage, arg5cage, arg6cage];
+
+    // println!("ns_chdir_handler: arg1 (path ptr) = {}, arg1cage = {}", arg1, arg1cage);
 
     let ns_cage = getcageid();
     let mut buf = vec![0u8; 4096];
@@ -178,7 +187,10 @@ macro_rules! fd_route_handler {
                 };
             }
 
-            helpers::do_syscall(arg1cage, $sysno, &args, &arg_cages)
+            let ret= helpers::do_syscall(arg1cage, $sysno, &args, &arg_cages);
+            let alt = helpers::get_route(arg1cage, $sysno).unwrap_or($sysno);
+            println!("ns_{}: arg1 (fd) = {}, ret = {}, alt = {}", stringify!($name), arg1, ret, alt);
+            ret
         }
     };
 }
@@ -195,6 +207,7 @@ fd_route_handler!(ns_writev_handler, SYS_WRITEV);
 fd_route_handler!(ns_pwritev_handler, SYS_PWRITEV);
 fd_route_handler!(ns_lseek_handler, SYS_LSEEK);
 fd_route_handler!(ns_fstat_handler, SYS_FXSTAT);
+fd_route_handler!(ns_fstatat_handler, SYS_NEWFSTATAT);
 fd_route_handler!(ns_ftruncate_handler, SYS_FTRUNCATE);
 fd_route_handler!(ns_fchmod_handler, SYS_FCHMOD);
 fd_route_handler!(ns_fchdir_handler, SYS_FCHDIR);
@@ -259,6 +272,7 @@ pub extern "C" fn ns_open_handler(
         );
     }
 
+    // println!("ns_open_handler: arg1 (path ptr) = {}, arg1cage = {}, ret = {}", arg1, arg1cage, ret);
     ret
 }
 
@@ -299,6 +313,7 @@ pub extern "C" fn ns_close_handler(
     // Always remove the fd from our tracking.
     let _ = fdtables::close_virtualfd(arg1cage, arg1);
 
+    println!("ns_close_handler: arg1 (fd) = {}, arg1cage = {}, ret = {}", arg1, arg1cage, ret);
     ret
 }
 
@@ -437,6 +452,8 @@ pub extern "C" fn ns_fcntl_handler(
             );
         }
     }
+
+    // println!("ns_fcntl_handler: arg1 (fd) = {}, arg1cage = {}, cmd = {}, ret = {}", arg1, arg1cage, arg2, ret);
 
     ret
 }
@@ -623,6 +640,7 @@ pub extern "C" fn ns_getcwd_handler(
     _arg6cage: u64,
 ) -> i32 {
     let ns_cage = getcageid();
+    // println!("ns_getcwd_handler: arg1 (buf ptr) = {}, arg1cage = {}, arg2cage = {}", arg1, arg1cage, arg2cage);
 
     let cwd = helpers::get_cage_cwd(arg2cage);
 
@@ -688,6 +706,7 @@ pub fn get_ns_handler(syscall_nr: u64) -> Option<SyscallHandler> {
         SYS_PWRITEV => Some(ns_pwritev_handler),
         SYS_LSEEK => Some(ns_lseek_handler),
         SYS_FXSTAT => Some(ns_fstat_handler),
+        SYS_NEWFSTATAT => Some(ns_fstatat_handler),
         SYS_FCNTL => Some(ns_fcntl_handler),
         SYS_FTRUNCATE => Some(ns_ftruncate_handler),
         SYS_FCHMOD => Some(ns_fchmod_handler),

--- a/rust-grates/fs-routing-clamp/src/handlers/ns_handlers.rs
+++ b/rust-grates/fs-routing-clamp/src/handlers/ns_handlers.rs
@@ -697,6 +697,7 @@ pub fn get_ns_handler(syscall_nr: u64) -> Option<SyscallHandler> {
         SYS_FSTATFS => Some(ns_fstatfs_handler),
         SYS_SYNC_FILE_RANGE => Some(ns_sync_file_range_handler),
         SYS_MMAP => Some(ns_mmap_handler),
+        SYS_MUNMAP => Some(ns_munmap_handler),
 
         // FD-based with fd-tracking side effects
         SYS_DUP => Some(ns_dup_handler),

--- a/rust-grates/fs-routing-clamp/src/helpers.rs
+++ b/rust-grates/fs-routing-clamp/src/helpers.rs
@@ -16,7 +16,7 @@ use grate_rs::{GrateError, copy_data_between_cages, make_threei_call};
 // These are all the calls that the fs-namespace grate cares about. All of the
 // following calls from the target must be routed through the grate regardless
 // of whether the clamp interposed on them.
-pub const FS_CALLS: [u64; 46] = [
+pub const FS_CALLS: [u64; 47] = [
     SYS_OPEN,
     SYS_OPENAT,
     SYS_XSTAT,
@@ -59,6 +59,7 @@ pub const FS_CALLS: [u64; 46] = [
     SYS_FSTATFS,
     SYS_SYNC_FILE_RANGE,
     SYS_MMAP,
+    SYS_MUNMAP,
     // FD-based with fd-tracking side effects
     SYS_DUP,
     SYS_DUP2,

--- a/rust-grates/fs-routing-clamp/src/helpers.rs
+++ b/rust-grates/fs-routing-clamp/src/helpers.rs
@@ -16,7 +16,7 @@ use grate_rs::{GrateError, copy_data_between_cages, make_threei_call};
 // These are all the calls that the fs-namespace grate cares about. All of the
 // following calls from the target must be routed through the grate regardless
 // of whether the clamp interposed on them.
-pub const FS_CALLS: [u64; 47] = [
+pub const FS_CALLS: [u64; 48] = [
     SYS_OPEN,
     SYS_OPENAT,
     SYS_XSTAT,
@@ -48,6 +48,7 @@ pub const FS_CALLS: [u64; 47] = [
     SYS_PWRITEV,
     SYS_LSEEK,
     SYS_FXSTAT,
+    SYS_NEWFSTATAT,
     SYS_FCNTL,
     SYS_FTRUNCATE,
     SYS_FCHMOD,


### PR DESCRIPTION
1. Remove default fd translation in fsrouting
2. Add munmap handler definition 

we only need fs-routing to distinguish whether the syscall needs to be redirected according to the fd, but fs-routing itself doesn’t actually do anything with fds.. so previous fd logics seems fine (just recording whether thisfd belongs to clamping cage, but no translation). 

Handle translations for all fds requires major refactoring to current code implementation. FSrouting needs to create actual virtual fd instead of just save a copy for underlying cages. This introducing unnecessary overhead and workload.