### PR TITLE
Expand chroot grate fd syscall coverage

### DIFF
--- a/lib/grate-rs/src/constants/syscall_numbers.rs
+++ b/lib/grate-rs/src/constants/syscall_numbers.rs
@@ -86,6 +86,8 @@ pub const SYS_SYMLINK: u64 = 88;
 pub const SYS_READLINK: u64 = 89;
 pub const SYS_CHMOD: u64 = 90;
 pub const SYS_FCHMOD: u64 = 91;
+pub const SYS_CHOWN: u64 = 92;
+pub const SYS_LCHOWN: u64 = 94;
 
 pub const SYS_GETUID: u64 = 102;
 pub const SYS_GETGID: u64 = 104;
@@ -98,6 +100,8 @@ pub const SYS_STATFS: u64 = 137;
 pub const SYS_FSTATFS: u64 = 138;
 pub const SYS_CHROOT: u64 = 161;
 pub const SYS_GETHOSTNAME: u64 = 170;
+pub const SYS_SETXATTR: u64 = 188;
+pub const SYS_LISTXATTR: u64 = 194;
 pub const SYS_FUTEX: u64 = 202;
 pub const SYS_EPOLL_CREATE: u64 = 213;
 pub const SYS_CLOCK_GETTIME: u64 = 228;
@@ -105,9 +109,14 @@ pub const SYS_EXIT_GROUP: u64 = 231;
 pub const SYS_EPOLL_WAIT: u64 = 232;
 pub const SYS_EPOLL_CTL: u64 = 233;
 pub const SYS_OPENAT: u64 = 257;
+pub const SYS_FCHOWNAT: u64 = 260;
+pub const SYS_NEWFSTATAT: u64 = 262;
 pub const SYS_UNLINKAT: u64 = 263;
+pub const SYS_RENAMEAT: u64 = 264;
 pub const SYS_SYMLINKAT: u64 = 266;
 pub const SYS_READLINKAT: u64 = 267;
+pub const SYS_FCHMODAT: u64 = 268;
+pub const SYS_FACCESSAT: u64 = 269;
 pub const SYS_PPOLL: u64 = 271;
 pub const SYS_SYNC_FILE_RANGE: u64 = 277;
 pub const SYS_UTIMENSAT: u64 = 280;
@@ -118,7 +127,9 @@ pub const SYS_PIPE2: u64 = 293;
 pub const SYS_PREADV: u64 = 295;
 pub const SYS_PWRITEV: u64 = 296;
 pub const SYS_PRLIMIT64: u64 = 302;
+pub const SYS_RENAMEAT2: u64 = 316;
 pub const SYS_GETRANDOM: u64 = 318;
+pub const SYS_STATX: u64 = 332;
 
 // --- Backwards-compat aliases ---
 //

--- a/rust-grates/chroot-grate/Cargo.toml
+++ b/rust-grates/chroot-grate/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2024"
 
 [dependencies]
 libc = "0.2"
-grate-rs = { git = "https://github.com/Lind-Project/lind-wasm-example-grates/", branch = "main", subdir = "/lib/grate-rs" }
+grate-rs = { path = "../../lib/grate-rs" }

--- a/rust-grates/chroot-grate/src/main.rs
+++ b/rust-grates/chroot-grate/src/main.rs
@@ -3,10 +3,12 @@
 use grate_rs::constants::fs::S_IFDIR;
 use grate_rs::constants::lind::GRATE_MEMORY_FLAG;
 use grate_rs::constants::{
-    SYS_ACCEPT, SYS_ACCESS, SYS_BIND, SYS_CHDIR, SYS_CHMOD, SYS_CHROOT, SYS_CLONE, SYS_CONNECT,
-    SYS_EXECVE, SYS_FCHDIR, SYS_GETCWD, SYS_GETPEERNAME, SYS_GETSOCKNAME, SYS_LINK, SYS_MKDIR,
-    SYS_OPEN, SYS_READLINK, SYS_READLINKAT, SYS_RECVFROM, SYS_RENAME, SYS_RMDIR, SYS_SENDTO,
-    SYS_STATFS, SYS_TRUNCATE, SYS_UNLINK, SYS_UNLINKAT, SYS_XSTAT,
+    SYS_ACCEPT, SYS_ACCESS, SYS_BIND, SYS_CHDIR, SYS_CHMOD, SYS_CHOWN, SYS_CHROOT, SYS_CLONE,
+    SYS_CONNECT, SYS_EXECVE, SYS_FACCESSAT, SYS_FCHDIR, SYS_FCHMODAT, SYS_FCHOWNAT, SYS_GETCWD,
+    SYS_GETPEERNAME, SYS_GETSOCKNAME, SYS_LCHOWN, SYS_LINK, SYS_LISTXATTR, SYS_MKDIR,
+    SYS_NEWFSTATAT, SYS_OPEN, SYS_READLINK, SYS_READLINKAT, SYS_RECVFROM, SYS_RENAME, SYS_RENAMEAT,
+    SYS_RENAMEAT2, SYS_RMDIR, SYS_SENDTO, SYS_SETXATTR, SYS_STATFS, SYS_STATX, SYS_SYMLINK,
+    SYS_SYMLINKAT, SYS_TRUNCATE, SYS_UNLINK, SYS_UNLINKAT, SYS_UTIMENSAT, SYS_XSTAT,
 };
 use grate_rs::ffi::stat;
 use grate_rs::{GrateBuilder, GrateError, copy_data_between_cages, getcageid, make_threei_call};
@@ -15,9 +17,9 @@ use std::ffi::CString;
 use std::ffi::c_char;
 use std::sync::Mutex;
 
+mod logging;
 mod paths;
 mod sockets;
-mod logging;
 
 use crate::paths::{
     chroot_path, get_cage_cwd, init_cwd, normalize_path, read_path_from_cage, register_cage,
@@ -144,6 +146,101 @@ fn write_bytes_to_cage(
     }
 }
 
+const AT_FDCWD: i64 = -100;
+
+fn make_syscall_from_grate(
+    syscall_no: u32,
+    target_cageid: u64,
+    args: [u64; 6],
+    arg_cages: [u64; 6],
+) -> i32 {
+    let thiscage = getcageid();
+    match make_threei_call(
+        syscall_no,
+        0,
+        thiscage,
+        target_cageid,
+        args[0],
+        arg_cages[0],
+        args[1],
+        arg_cages[1],
+        args[2],
+        arg_cages[2],
+        args[3],
+        arg_cages[3],
+        args[4],
+        arg_cages[4],
+        args[5],
+        arg_cages[5],
+        0,
+    ) {
+        Ok(r) => r,
+        Err(GrateError::MakeSyscallError(n)) => n,
+        Err(_) => -1,
+    }
+}
+
+fn rewrite_at_path(
+    cageid: u64,
+    dirfd: u64,
+    path_ptr: u64,
+    path_cage: u64,
+) -> Result<(u64, CString), i32> {
+    let path = match read_path_from_cage(path_ptr, path_cage) {
+        Some(p) => p,
+        None => return Err(-(libc::EFAULT as i32)),
+    };
+
+    let (rewritten_dirfd, rewritten_path) = if path.starts_with('/') || dirfd as i64 == AT_FDCWD {
+        (AT_FDCWD as u64, chroot_path(&path, cageid))
+    } else {
+        (dirfd, path)
+    };
+
+    match CString::new(rewritten_path) {
+        Ok(path) => Ok((rewritten_dirfd, path)),
+        Err(_) => Err(-(libc::EINVAL as i32)),
+    }
+}
+
+fn call_with_at_path(
+    syscall_no: u32,
+    cageid: u64,
+    target_cageid: u64,
+    mut args: [u64; 6],
+    mut arg_cages: [u64; 6],
+    dirfd_idx: usize,
+    path_idx: usize,
+) -> i32 {
+    let thiscage = getcageid();
+    let (dirfd, c_path) =
+        match rewrite_at_path(cageid, args[dirfd_idx], args[path_idx], arg_cages[path_idx]) {
+            Ok(v) => v,
+            Err(e) => return e,
+        };
+
+    args[dirfd_idx] = dirfd;
+    args[path_idx] = c_path.as_ptr() as u64;
+    arg_cages[path_idx] = thiscage | GRATE_MEMORY_FLAG;
+
+    make_syscall_from_grate(syscall_no, target_cageid, args, arg_cages)
+}
+
+fn rewrite_symlink_target(cageid: u64, target_ptr: u64, target_cage: u64) -> Result<CString, i32> {
+    let target = match read_path_from_cage(target_ptr, target_cage) {
+        Some(p) => p,
+        None => return Err(-(libc::EFAULT as i32)),
+    };
+
+    let rewritten = if target.starts_with('/') {
+        chroot_path(&target, cageid)
+    } else {
+        target
+    };
+
+    CString::new(rewritten).map_err(|_| -(libc::EINVAL as i32))
+}
+
 // -----------------------------------------------------------------------------
 // Macro-generated handler declarations
 // -----------------------------------------------------------------------------
@@ -159,7 +256,11 @@ input_path_handler!(mkdir_handler, SYS_MKDIR, 0);
 input_path_handler!(rmdir_handler, SYS_RMDIR, 0);
 input_path_handler!(unlink_handler, SYS_UNLINK, 0);
 input_path_handler!(chmod_handler, SYS_CHMOD, 0);
+input_path_handler!(chown_handler, SYS_CHOWN, 0);
+input_path_handler!(lchown_handler, SYS_LCHOWN, 0);
 input_path_handler!(truncate_handler, SYS_TRUNCATE, 0);
+input_path_handler!(setxattr_handler, SYS_SETXATTR, 0);
+input_path_handler!(listxattr_handler, SYS_LISTXATTR, 0);
 
 // Two-path syscalls: chroot both path arguments.
 input_path_handler!(rename_handler, SYS_RENAME, 0, 1);
@@ -405,6 +506,408 @@ extern "C" fn unlinkat_handler(
         Err(GrateError::MakeSyscallError(n)) => n,
         Err(_) => -1,
     }
+}
+
+extern "C" fn symlink_handler(
+    cageid: u64,
+    target_ptr: u64,
+    target_cage: u64,
+    linkpath_ptr: u64,
+    linkpath_cage: u64,
+    arg3: u64,
+    arg3cage: u64,
+    arg4: u64,
+    arg4cage: u64,
+    arg5: u64,
+    arg5cage: u64,
+    arg6: u64,
+    arg6cage: u64,
+) -> i32 {
+    let thiscage = getcageid();
+
+    let target = match rewrite_symlink_target(cageid, target_ptr, target_cage) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let linkpath = match read_path_from_cage(linkpath_ptr, linkpath_cage) {
+        Some(p) => p,
+        None => return -(libc::EFAULT as i32),
+    };
+    let linkpath = match CString::new(chroot_path(&linkpath, cageid)) {
+        Ok(v) => v,
+        Err(_) => return -(libc::EINVAL as i32),
+    };
+
+    make_syscall_from_grate(
+        SYS_SYMLINK as u32,
+        target_cage,
+        [
+            target.as_ptr() as u64,
+            linkpath.as_ptr() as u64,
+            arg3,
+            arg4,
+            arg5,
+            arg6,
+        ],
+        [
+            thiscage | GRATE_MEMORY_FLAG,
+            thiscage | GRATE_MEMORY_FLAG,
+            arg3cage,
+            arg4cage,
+            arg5cage,
+            arg6cage,
+        ],
+    )
+}
+
+extern "C" fn symlinkat_handler(
+    cageid: u64,
+    target_ptr: u64,
+    target_cage: u64,
+    dirfd: u64,
+    dirfd_cage: u64,
+    linkpath_ptr: u64,
+    linkpath_cage: u64,
+    arg4: u64,
+    arg4cage: u64,
+    arg5: u64,
+    arg5cage: u64,
+    arg6: u64,
+    arg6cage: u64,
+) -> i32 {
+    let thiscage = getcageid();
+
+    let target = match rewrite_symlink_target(cageid, target_ptr, target_cage) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let (rewritten_dirfd, linkpath) =
+        match rewrite_at_path(cageid, dirfd, linkpath_ptr, linkpath_cage) {
+            Ok(v) => v,
+            Err(e) => return e,
+        };
+
+    make_syscall_from_grate(
+        SYS_SYMLINKAT as u32,
+        dirfd_cage,
+        [
+            target.as_ptr() as u64,
+            rewritten_dirfd,
+            linkpath.as_ptr() as u64,
+            arg4,
+            arg5,
+            arg6,
+        ],
+        [
+            thiscage | GRATE_MEMORY_FLAG,
+            dirfd_cage,
+            thiscage | GRATE_MEMORY_FLAG,
+            arg4cage,
+            arg5cage,
+            arg6cage,
+        ],
+    )
+}
+
+extern "C" fn faccessat_handler(
+    cageid: u64,
+    dirfd: u64,
+    dirfd_cage: u64,
+    path_ptr: u64,
+    path_cage: u64,
+    mode: u64,
+    mode_cage: u64,
+    flags: u64,
+    flags_cage: u64,
+    arg5: u64,
+    arg5cage: u64,
+    arg6: u64,
+    arg6cage: u64,
+) -> i32 {
+    call_with_at_path(
+        SYS_FACCESSAT as u32,
+        cageid,
+        dirfd_cage,
+        [dirfd, path_ptr, mode, flags, arg5, arg6],
+        [
+            dirfd_cage, path_cage, mode_cage, flags_cage, arg5cage, arg6cage,
+        ],
+        0,
+        1,
+    )
+}
+
+extern "C" fn fchmodat_handler(
+    cageid: u64,
+    dirfd: u64,
+    dirfd_cage: u64,
+    path_ptr: u64,
+    path_cage: u64,
+    mode: u64,
+    mode_cage: u64,
+    flags: u64,
+    flags_cage: u64,
+    arg5: u64,
+    arg5cage: u64,
+    arg6: u64,
+    arg6cage: u64,
+) -> i32 {
+    call_with_at_path(
+        SYS_FCHMODAT as u32,
+        cageid,
+        dirfd_cage,
+        [dirfd, path_ptr, mode, flags, arg5, arg6],
+        [
+            dirfd_cage, path_cage, mode_cage, flags_cage, arg5cage, arg6cage,
+        ],
+        0,
+        1,
+    )
+}
+
+extern "C" fn fchownat_handler(
+    cageid: u64,
+    dirfd: u64,
+    dirfd_cage: u64,
+    path_ptr: u64,
+    path_cage: u64,
+    owner: u64,
+    owner_cage: u64,
+    group: u64,
+    group_cage: u64,
+    flags: u64,
+    flags_cage: u64,
+    arg6: u64,
+    arg6cage: u64,
+) -> i32 {
+    call_with_at_path(
+        SYS_FCHOWNAT as u32,
+        cageid,
+        dirfd_cage,
+        [dirfd, path_ptr, owner, group, flags, arg6],
+        [
+            dirfd_cage, path_cage, owner_cage, group_cage, flags_cage, arg6cage,
+        ],
+        0,
+        1,
+    )
+}
+
+extern "C" fn fstatat_handler(
+    cageid: u64,
+    dirfd: u64,
+    dirfd_cage: u64,
+    path_ptr: u64,
+    path_cage: u64,
+    statbuf: u64,
+    statbuf_cage: u64,
+    flags: u64,
+    flags_cage: u64,
+    arg5: u64,
+    arg5cage: u64,
+    arg6: u64,
+    arg6cage: u64,
+) -> i32 {
+    call_with_at_path(
+        SYS_NEWFSTATAT as u32,
+        cageid,
+        dirfd_cage,
+        [dirfd, path_ptr, statbuf, flags, arg5, arg6],
+        [
+            dirfd_cage,
+            path_cage,
+            statbuf_cage,
+            flags_cage,
+            arg5cage,
+            arg6cage,
+        ],
+        0,
+        1,
+    )
+}
+
+extern "C" fn statx_handler(
+    cageid: u64,
+    dirfd: u64,
+    dirfd_cage: u64,
+    path_ptr: u64,
+    path_cage: u64,
+    flags: u64,
+    flags_cage: u64,
+    mask: u64,
+    mask_cage: u64,
+    statxbuf: u64,
+    statxbuf_cage: u64,
+    arg6: u64,
+    arg6cage: u64,
+) -> i32 {
+    call_with_at_path(
+        SYS_STATX as u32,
+        cageid,
+        dirfd_cage,
+        [dirfd, path_ptr, flags, mask, statxbuf, arg6],
+        [
+            dirfd_cage,
+            path_cage,
+            flags_cage,
+            mask_cage,
+            statxbuf_cage,
+            arg6cage,
+        ],
+        0,
+        1,
+    )
+}
+
+extern "C" fn utimensat_handler(
+    cageid: u64,
+    dirfd: u64,
+    dirfd_cage: u64,
+    path_ptr: u64,
+    path_cage: u64,
+    times: u64,
+    times_cage: u64,
+    flags: u64,
+    flags_cage: u64,
+    arg5: u64,
+    arg5cage: u64,
+    arg6: u64,
+    arg6cage: u64,
+) -> i32 {
+    let args = [dirfd, path_ptr, times, flags, arg5, arg6];
+    let arg_cages = [
+        dirfd_cage, path_cage, times_cage, flags_cage, arg5cage, arg6cage,
+    ];
+
+    if path_ptr == 0 {
+        return make_syscall_from_grate(SYS_UTIMENSAT as u32, dirfd_cage, args, arg_cages);
+    }
+
+    call_with_at_path(
+        SYS_UTIMENSAT as u32,
+        cageid,
+        dirfd_cage,
+        args,
+        arg_cages,
+        0,
+        1,
+    )
+}
+
+extern "C" fn renameat_handler(
+    cageid: u64,
+    olddirfd: u64,
+    olddirfd_cage: u64,
+    oldpath_ptr: u64,
+    oldpath_cage: u64,
+    newdirfd: u64,
+    newdirfd_cage: u64,
+    newpath_ptr: u64,
+    newpath_cage: u64,
+    arg5: u64,
+    arg5cage: u64,
+    arg6: u64,
+    arg6cage: u64,
+) -> i32 {
+    renameat_common(
+        SYS_RENAMEAT as u32,
+        cageid,
+        olddirfd,
+        olddirfd_cage,
+        oldpath_ptr,
+        oldpath_cage,
+        newdirfd,
+        newdirfd_cage,
+        newpath_ptr,
+        newpath_cage,
+        arg5,
+        arg5cage,
+        arg6,
+        arg6cage,
+    )
+}
+
+extern "C" fn renameat2_handler(
+    cageid: u64,
+    olddirfd: u64,
+    olddirfd_cage: u64,
+    oldpath_ptr: u64,
+    oldpath_cage: u64,
+    newdirfd: u64,
+    newdirfd_cage: u64,
+    newpath_ptr: u64,
+    newpath_cage: u64,
+    flags: u64,
+    flags_cage: u64,
+    arg6: u64,
+    arg6cage: u64,
+) -> i32 {
+    renameat_common(
+        SYS_RENAMEAT2 as u32,
+        cageid,
+        olddirfd,
+        olddirfd_cage,
+        oldpath_ptr,
+        oldpath_cage,
+        newdirfd,
+        newdirfd_cage,
+        newpath_ptr,
+        newpath_cage,
+        flags,
+        flags_cage,
+        arg6,
+        arg6cage,
+    )
+}
+
+fn renameat_common(
+    syscall_no: u32,
+    cageid: u64,
+    olddirfd: u64,
+    olddirfd_cage: u64,
+    oldpath_ptr: u64,
+    oldpath_cage: u64,
+    newdirfd: u64,
+    newdirfd_cage: u64,
+    newpath_ptr: u64,
+    newpath_cage: u64,
+    arg5: u64,
+    arg5cage: u64,
+    arg6: u64,
+    arg6cage: u64,
+) -> i32 {
+    let thiscage = getcageid();
+    let (rewritten_olddirfd, oldpath) =
+        match rewrite_at_path(cageid, olddirfd, oldpath_ptr, oldpath_cage) {
+            Ok(v) => v,
+            Err(e) => return e,
+        };
+    let (rewritten_newdirfd, newpath) =
+        match rewrite_at_path(cageid, newdirfd, newpath_ptr, newpath_cage) {
+            Ok(v) => v,
+            Err(e) => return e,
+        };
+
+    make_syscall_from_grate(
+        syscall_no,
+        olddirfd_cage,
+        [
+            rewritten_olddirfd,
+            oldpath.as_ptr() as u64,
+            rewritten_newdirfd,
+            newpath.as_ptr() as u64,
+            arg5,
+            arg6,
+        ],
+        [
+            olddirfd_cage,
+            thiscage | GRATE_MEMORY_FLAG,
+            newdirfd_cage,
+            thiscage | GRATE_MEMORY_FLAG,
+            arg5cage,
+            arg6cage,
+        ],
+    )
 }
 
 // -----------------------------------------------------------------------------
@@ -718,16 +1221,30 @@ fn main() {
         .register(SYS_OPEN, open_handler)
         .register(SYS_EXECVE, execve_handler)
         .register(SYS_XSTAT, stat_handler)
+        .register(SYS_NEWFSTATAT, fstatat_handler)
+        .register(SYS_STATX, statx_handler)
         .register(SYS_ACCESS, access_handler)
+        .register(SYS_FACCESSAT, faccessat_handler)
         .register(SYS_STATFS, statfs_handler)
         .register(SYS_MKDIR, mkdir_handler)
         .register(SYS_RMDIR, rmdir_handler)
         .register(SYS_UNLINK, unlink_handler)
         .register(SYS_UNLINKAT, unlinkat_handler)
         .register(SYS_RENAME, rename_handler)
+        .register(SYS_RENAMEAT, renameat_handler)
+        .register(SYS_RENAMEAT2, renameat2_handler)
         .register(SYS_LINK, link_handler)
+        .register(SYS_SYMLINK, symlink_handler)
+        .register(SYS_SYMLINKAT, symlinkat_handler)
         .register(SYS_CHMOD, chmod_handler)
+        .register(SYS_FCHMODAT, fchmodat_handler)
+        .register(SYS_CHOWN, chown_handler)
+        .register(SYS_LCHOWN, lchown_handler)
+        .register(SYS_FCHOWNAT, fchownat_handler)
         .register(SYS_TRUNCATE, truncate_handler)
+        .register(SYS_SETXATTR, setxattr_handler)
+        .register(SYS_LISTXATTR, listxattr_handler)
+        .register(SYS_UTIMENSAT, utimensat_handler)
         .register(SYS_CHDIR, chdir_handler)
         .register(SYS_FCHDIR, fchdir_handler)
         .register(SYS_GETCWD, getcwd_handler)

--- a/rust-grates/chroot-grate/test/chroot-test.c
+++ b/rust-grates/chroot-grate/test/chroot-test.c
@@ -54,12 +54,24 @@ int main(int argc, char *argv[]) {
     char b[64];
     char c[64];
     char sym[64];
+    char symhard[64];
+    char symat[64];
+    char missing[64];
+    char absmissing[80];
+    char at1[64];
+    char at2[64];
 
     snprintf(dir, sizeof(dir), "sub-%s", seed);
     snprintf(a, sizeof(a), "a.txt-%s", seed);
     snprintf(b, sizeof(b), "b.txt-%s", seed);
     snprintf(c, sizeof(c), "c.txt-%s", seed);
     snprintf(sym, sizeof(sym), "sym-%s", seed);
+    snprintf(symhard, sizeof(symhard), "sym-hard-%s", seed);
+    snprintf(symat, sizeof(symat), "symat-%s", seed);
+    snprintf(missing, sizeof(missing), "missing-%s", seed);
+    snprintf(absmissing, sizeof(absmissing), "/missing-abs-%s", seed);
+    snprintf(at1, sizeof(at1), "at1.txt-%s", seed);
+    snprintf(at2, sizeof(at2), "at2.txt-%s", seed);
 
     // ---- mkdir ----
     CHECK("mkdir: create subdirectory", mkdir(dir, 0755) == 0 || errno == EEXIST);
@@ -91,6 +103,31 @@ int main(int argc, char *argv[]) {
     // ---- rename ----
     CHECK("rename: rename hard link", rename(b, c) == 0);
 
+    // ---- symlink ----
+    CHECK("symlink: create dangling relative symlink", symlink(missing, sym) == 0);
+    char linkbuf[PATH_MAX];
+    ssize_t linklen = readlink(sym, linkbuf, sizeof(linkbuf) - 1);
+    if (linklen >= 0) {
+        linkbuf[linklen] = '\0';
+    }
+    CHECK("readlink: relative symlink target is preserved", linklen >= 0 && strcmp(linkbuf, missing) == 0);
+    CHECK("link: hardlink dangling symlink itself", link(sym, symhard) == 0);
+    linklen = readlink(symhard, linkbuf, sizeof(linkbuf) - 1);
+    if (linklen >= 0) {
+        linkbuf[linklen] = '\0';
+    }
+    CHECK("readlink: hardlinked symlink target is preserved", linklen >= 0 && strcmp(linkbuf, missing) == 0);
+    CHECK("unlink: remove hardlinked symlink", unlink(symhard) == 0);
+    CHECK("unlink: remove relative symlink", unlink(sym) == 0);
+
+    CHECK("symlink: create dangling absolute symlink", symlink(absmissing, sym) == 0);
+    linklen = readlink(sym, linkbuf, sizeof(linkbuf) - 1);
+    if (linklen >= 0) {
+        linkbuf[linklen] = '\0';
+    }
+    CHECK("readlink: absolute symlink target succeeds", linklen >= 0);
+    CHECK("unlink: remove absolute symlink", unlink(sym) == 0);
+
     // ---- unlink ----
     CHECK("unlink: remove original file", unlink(a) == 0);
 
@@ -99,6 +136,23 @@ int main(int argc, char *argv[]) {
     CHECK("open: open current directory as fd", dfd >= 0);
     if (dfd >= 0) {
         CHECK("unlinkat: remove renamed file via dirfd", unlinkat(dfd, c, 0) == 0);
+
+        int atfd = openat(dfd, at1, O_CREAT | O_RDWR, 0644);
+        CHECK("openat: create file relative to dirfd", atfd >= 0);
+        if (atfd >= 0) {
+            CHECK("write: populate openat-created file", write(atfd, "atdata", 6) == 6);
+            close(atfd);
+        }
+
+        CHECK("faccessat: check dirfd-relative file", faccessat(dfd, at1, F_OK, 0) == 0);
+        CHECK("fstatat: retrieve dirfd-relative metadata", fstatat(dfd, at1, &st, 0) == 0);
+        CHECK("fchmodat: change dirfd-relative permissions", fchmodat(dfd, at1, 0600, 0) == 0);
+        CHECK("fstatat: verify fchmodat mode", fstatat(dfd, at1, &st, 0) == 0 && (st.st_mode & 0777) == 0600);
+        CHECK("utimensat: update dirfd-relative timestamps", utimensat(dfd, at1, NULL, 0) == 0);
+        CHECK("unlinkat: remove fd-relative file", unlinkat(dfd, at1, 0) == 0);
+        CHECK("symlinkat: create dangling symlink relative to dirfd", symlinkat(missing, dfd, symat) == 0);
+        CHECK("unlinkat: remove symlinkat result", unlinkat(dfd, symat, 0) == 0);
+
         close(dfd);
     }
 


### PR DESCRIPTION
## Summary

  Expands `chroot-grate` syscall coverage for newer fd-relative and metadata filesystem paths, and adds symlink handling so symlink creation resolves the link location inside the chroot
  while preserving virtual target behavior.

  ## Changes

  - Adds missing syscall constants in `grate-rs`.
  - Registers new `chroot-grate` handlers for:
    - `faccessat`
    - `newfstatat`
    - `statx`
    - `fchmodat`
    - `chown` / `lchown`
    - `fchownat`
    - `renameat` / `renameat2`
    - `utimensat`
    - `setxattr` / `listxattr`
    - `symlink` / `symlinkat`
  - Adds dirfd-aware path rewriting for `*at` syscalls.
  - Adds symlink behavior:
    - link path is rewritten into the chroot jail
    - relative targets are preserved
    - absolute targets are rewritten to the host chroot path, then exposed back as virtual paths through existing `readlink` handling
  - Extends `chroot-test.c` with coverage for fd-relative metadata calls and dangling symlink cases.

  ## Testing

  - `cargo fmt`
  - `cargo check` in `rust-grates/chroot-grate`
  - `gcc -fsyntax-only rust-grates/chroot-grate/test/chroot-test.c`
  - `git diff --check`