### PR TITLE
fs-routing-clamp: fork_handler() gets overwriten by ns_clone_handler()

### DIFF
--- a/rust-grates/fs-routing-clamp/src/helpers.rs
+++ b/rust-grates/fs-routing-clamp/src/helpers.rs
@@ -18,12 +18,11 @@ pub const SYS_LINKAT_NR: u64 = 265;
 // These are all the calls that the fs-namespace grate cares about. All of the
 // following calls from the target must be routed through the grate regardless
 // of whether the clamp interposed on them.
-pub const FS_CALLS: [u64; 59] = [
+pub const FS_CALLS: [u64; 57] = [
     SYS_OPEN,
     SYS_OPENAT,
     SYS_XSTAT,
     SYS_LSTAT,
-    SYS_GETCWD,
     SYS_ACCESS,
     SYS_UNLINK,
     SYS_LINK,
@@ -79,7 +78,6 @@ pub const FS_CALLS: [u64; 59] = [
     SYS_DUP2,
     SYS_DUP3,
     // Lifecycle — interpose so we track child cages
-    SYS_CLONE,
     SYS_GETCWD,
 ];
 


### PR DESCRIPTION
- fork_handler() gets registered for SYS_CLONE on fork of initial child cage via register_lifecycle_handlers(child). on clamp boundry, exec_handler calls register_target_handlers(arg1cage) which loops through FS_CALLS array that includes an entry for SYS_CLONE. this overrides fork_handler() with ns_clone_handler() which does not copy fdtable to the child, causing a panic.
- removes duplicate entry for SYS_GETCWD