### PR TITLE
Add Rust IMFS preload and dump support via 3i syscalls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ target
 #.idea/
 
 .DS_Store
+
+**/Cargo.lock

--- a/rust-grates/imfs-grate/README.md
+++ b/rust-grates/imfs-grate/README.md
@@ -1,0 +1,141 @@
+# imfs-grate
+
+Rust implementation of the Lind IMFS grate. It intercepts filesystem syscalls
+and serves them from an in-memory filesystem, while still allowing selected host
+files to be staged in before execution and selected IMFS files to be dumped back
+after execution.
+
+## Build
+
+```bash
+cd rust-grates/imfs-grate
+cargo lind_compile --output-dir grates
+```
+
+The generated grate is typically run as:
+
+```bash
+lind_run grates/imfs-grate.cwasm <program> [args...]
+```
+
+Add `--log` immediately after the grate to enable IMFS logging:
+
+```bash
+lind_run grates/imfs-grate.cwasm --log <program> [args...]
+```
+
+## Preloading Host Files
+
+Set `PRELOADS` to a colon-separated list of host paths. Each regular file is
+read from the host and created in IMFS at the same path.
+
+```bash
+lind_run \
+  --env PRELOADS="/hello.c:/usr/include/stdio.h" \
+  grates/imfs-grate.cwasm --log bin/tcc /hello.c -o /hello-3i
+```
+
+Use absolute IMFS paths when the program expects absolute paths. For example,
+if `tcc` is invoked with `/hello.c`, preload `/hello.c`, not `hello.c`.
+
+Preload details:
+
+- Entries are separated with `:`.
+- Empty entries are ignored.
+- Non-regular files are skipped.
+- Parent directories are created in IMFS as needed.
+- The Rust implementation reads host files through `make_threei_call`
+  (`stat`, `open`, `read`, `close`) instead of `std::fs::read`.
+
+This avoids a Lind/WASM issue where Rust `std::fs::metadata()` can report an
+incorrectly huge file size, causing `std::fs::read()` to fail with out-of-memory
+even for tiny files.
+
+## Dumping IMFS Files Back
+
+Set `DUMPS` to a semicolon-separated list. Each entry is either:
+
+```text
+imfs_path=host_path
+```
+
+or just:
+
+```text
+path
+```
+
+When `=` is omitted, the same path is used for both IMFS and host.
+
+Dumping happens during grate teardown, after the child cage exits.
+
+```bash
+lind_run \
+  --env PRELOADS="/hello.c" \
+  --env DUMPS="/hello-3i=hello-3i" \
+  grates/imfs-grate.cwasm --log bin/tcc /hello.c -o /hello-3i
+```
+
+This compiles `/hello.c` inside IMFS and writes the generated `/hello-3i` back
+to the host as `hello-3i`.
+
+Dump details:
+
+- Entries are separated with `;`.
+- Leading spaces and tabs in each entry are ignored.
+- Host parent directories are created before writing the dump target.
+- Host-side `mkdir`, `open`, `write`, and `close` are performed through
+  `make_threei_call`.
+
+## Common tcc Example
+
+For a small C compile inside IMFS, preload the compiler inputs and dump the
+output binary:
+
+```bash
+lind_run \
+  --env PRELOADS="/usr/lib/i386-linux-gnu/crt1.o:/usr/lib/i386-linux-gnu/crti.o:/usr/include/stdio.h:/usr/lib/i386-linux-gnu/libc.so.6:/usr/lib/i386-linux-gnu/crtn.o:/hello.c" \
+  --env DUMPS="/hello-3i=hello-3i" \
+  grates/imfs-grate.cwasm --log bin/tcc /hello.c -o /hello-3i
+```
+
+If `tcc` reports `undefined symbol 'main'`, first verify that the source file
+was preloaded at the same path passed to `tcc`. In practice, `/hello.c` is safer
+than `hello.c` because the target program's current working directory may not
+match the host shell's current directory.
+
+## Symlink Notes
+
+IMFS supports symlink syscalls, but `PRELOADS` currently stages regular files by
+path. If a program expects a dynamic loader or libc at a different path, either
+preload the file at the path the program opens or create the required symlink in
+the environment before running.
+
+Do not symlink a 64-bit libc into an i386 libc path for 32-bit programs. A
+32-bit program needs the i386 libc, for example `libc6:i386` on Debian/Ubuntu.
+
+## Intercepted Syscalls
+
+The Rust IMFS grate registers handlers for common filesystem and lifecycle
+syscalls, including:
+
+```text
+open, openat, close, read, write, pread, pwrite, readv, writev,
+lseek, fcntl, getdents, stat, lstat, fstat, fstatat, statfs, fstatfs,
+access, faccessat, mkdir, rmdir, unlink, unlinkat, link, linkat,
+rename, renameat, renameat2, symlink, symlinkat, readlink, readlinkat,
+chmod, fchmod, fchmodat, chown, lchown, fchownat,
+truncate, ftruncate, chdir, fchdir, fsync, fdatasync,
+clone, exec
+```
+
+Unsupported or intentionally disabled paths return the appropriate negative
+errno where possible.
+
+## Current Limitations
+
+- `PRELOADS` does not yet support `source=target` remapping.
+- Preloaded paths are stored in IMFS using the path string provided.
+- Large preload files are still accumulated in memory before being written into
+  IMFS; the host read path is chunked, but the temporary buffer is a `Vec<u8>`.
+- `pipe` and `pipe2` are currently registered as unsupported.

--- a/rust-grates/imfs-grate/src/main.rs
+++ b/rust-grates/imfs-grate/src/main.rs
@@ -13,10 +13,17 @@ mod imfs;
 mod logging;
 
 use grate_rs::constants::fs::O_RDWR;
+use grate_rs::constants::lind::GRATE_MEMORY_FLAG;
 use grate_rs::constants::*;
-use grate_rs::{GrateBuilder, GrateError};
+use grate_rs::ffi::stat;
+use grate_rs::{GrateBuilder, GrateError, getcageid, make_threei_call};
+use std::ffi::CString;
 
 const SYS_LINKAT: u64 = 265;
+const PRELOAD_READ_CHUNK_SIZE: usize = 4096;
+const DUMP_WRITE_CHUNK_SIZE: usize = 1024;
+const S_IFMT: u32 = 0o170000;
+const S_IFREG: u32 = 0o100000;
 
 struct Config {
     argv: Vec<String>,
@@ -45,6 +52,7 @@ fn parse_argv(args: Vec<String>) -> Config {
 fn main() {
     let config = parse_argv(std::env::args().skip(1).collect());
     logging::init(config.log_enabled);
+    let dump_files = std::env::var("DUMPS").ok();
 
     // Initialize the in-memory filesystem.
     imfs::init();
@@ -139,7 +147,10 @@ fn main() {
                 imfs::with_imfs(|s| s.insert_perfdinfo(cageid as u64, fd, O_RDWR as u64));
             }
         })
-        .teardown(|result: Result<i32, GrateError>| {
+        .teardown(move |result: Result<i32, GrateError>| {
+            if let Some(dumps) = dump_files.as_deref() {
+                dump_outputs(dumps);
+            }
             log!("exited: {:?}", result);
         })
         .run(config.argv);
@@ -151,6 +162,10 @@ fn main() {
 /// Each file is read from the host and written into IMFS at the same path,
 /// creating parent directories as needed.
 fn load_preloads(preloads: &str) {
+    // Preload/dump utilities use IMFS cage 0 because they run before any
+    // application cage exists. Initialize its fd table once for all utility I/O.
+    init_utility_cage();
+
     for path in preloads.split(':') {
         if path.is_empty() {
             continue;
@@ -158,8 +173,12 @@ fn load_preloads(preloads: &str) {
 
         log!("preloading: {}", path);
 
-        // Read the file from the host filesystem.
-        let data = match std::fs::read(path) {
+        if !preload_is_regular_file(path) {
+            continue;
+        }
+
+        // Read the file from the host filesystem through 3i, bypassing IMFS.
+        let data = match read_preload_file(path) {
             Ok(d) => d,
             Err(e) => {
                 log!("failed to read {}: {}", path, e);
@@ -181,9 +200,6 @@ fn load_preloads(preloads: &str) {
                 }
             }
 
-            // Use cage_id 0 for preloading (before any cage exists).
-            fdtables::init_empty_cage(0);
-
             // Create and write the file.
             let fd = state.open(0, path, fs::O_CREAT | fs::O_WRONLY, 0o777);
             if fd >= 0 {
@@ -191,5 +207,342 @@ fn load_preloads(preloads: &str) {
                 state.close(0, fd as u64);
             }
         });
+    }
+}
+
+fn preload_is_regular_file(path: &str) -> bool {
+    let c_path = match CString::new(path) {
+        Ok(path) => path,
+        Err(_) => return false,
+    };
+
+    // Match the C implementation: only regular files are staged into IMFS.
+    // The pathname and stat buffer live in this grate's memory, so mark their
+    // cage IDs with GRATE_MEMORY_FLAG before passing them through ThreeI.
+    let this_cage = getcageid();
+    let mut st = stat::default();
+    let ret = raw_threei_syscall(
+        SYS_STAT,
+        [
+            c_path.as_ptr() as u64,
+            &mut st as *mut stat as u64,
+            0,
+            0,
+            0,
+            0,
+        ],
+        [
+            this_cage | GRATE_MEMORY_FLAG,
+            this_cage | GRATE_MEMORY_FLAG,
+            this_cage,
+            this_cage,
+            this_cage,
+            this_cage,
+        ],
+    );
+
+    ret >= 0 && (st.st_mode & S_IFMT) == S_IFREG
+}
+
+fn read_preload_file(path: &str) -> Result<Vec<u8>, String> {
+    let c_path = CString::new(path).map_err(|_| "path contains interior NUL".to_string())?;
+    let this_cage = getcageid();
+
+    // Do not use std::fs here. In lind-wasm, Rust std metadata can report a
+    // bogus huge file size and make std::fs::read try to allocate too much.
+    // Use the underlying host syscalls via 3i, like the C grate does.
+    let fd = raw_threei_syscall(
+        SYS_OPEN,
+        [c_path.as_ptr() as u64, fs::O_RDONLY as u64, 0, 0, 0, 0],
+        [
+            this_cage | GRATE_MEMORY_FLAG,
+            this_cage,
+            this_cage,
+            this_cage,
+            this_cage,
+            this_cage,
+        ],
+    );
+    if fd < 0 {
+        return Err(format!("open failed: {}", fd));
+    }
+
+    let mut data = Vec::new();
+    let mut buf = [0u8; PRELOAD_READ_CHUNK_SIZE];
+
+    // Read in bounded chunks from the host, then write the complete contents
+    // into the IMFS node after the host fd has been closed.
+    loop {
+        let nread = raw_threei_syscall(
+            SYS_READ,
+            [
+                fd as u64,
+                buf.as_mut_ptr() as u64,
+                buf.len() as u64,
+                0,
+                0,
+                0,
+            ],
+            [
+                this_cage,
+                this_cage | GRATE_MEMORY_FLAG,
+                this_cage,
+                this_cage,
+                this_cage,
+                this_cage,
+            ],
+        );
+
+        if nread < 0 {
+            let _ = raw_threei_syscall(
+                SYS_CLOSE,
+                [fd as u64, 0, 0, 0, 0, 0],
+                [
+                    this_cage, this_cage, this_cage, this_cage, this_cage, this_cage,
+                ],
+            );
+            return Err(format!("read failed: {}", nread));
+        }
+
+        if nread == 0 {
+            break;
+        }
+
+        data.extend_from_slice(&buf[..nread as usize]);
+    }
+
+    let close_ret = raw_threei_syscall(
+        SYS_CLOSE,
+        [fd as u64, 0, 0, 0, 0, 0],
+        [
+            this_cage, this_cage, this_cage, this_cage, this_cage, this_cage,
+        ],
+    );
+    if close_ret < 0 {
+        return Err(format!("close failed: {}", close_ret));
+    }
+
+    Ok(data)
+}
+
+fn dump_outputs(dumps: &str) {
+    if dumps.is_empty() {
+        return;
+    }
+
+    // DUMPS follows the C grate format:
+    //   imfs_path=host_path;other_imfs_path=other_host_path
+    // If '=' is omitted, the same path is used on both sides.
+    init_utility_cage();
+
+    for entry in dumps.split(';') {
+        let entry = entry.trim_start_matches([' ', '\t']);
+        if entry.is_empty() {
+            continue;
+        }
+
+        let (imfs_path, actual_path) = match entry.split_once('=') {
+            Some((imfs_path, actual_path)) => (imfs_path, actual_path),
+            None => (entry, entry),
+        };
+
+        if imfs_path.is_empty() || actual_path.is_empty() {
+            continue;
+        }
+
+        log!("dumping {} -> {}", imfs_path, actual_path);
+        if let Err(e) = dump_file(imfs_path, actual_path) {
+            log!("failed to dump {} -> {}: {}", imfs_path, actual_path, e);
+        }
+    }
+}
+
+fn init_utility_cage() {
+    // fdtables panics if a cage is initialized twice, so preload and dump share
+    // this guard instead of calling init_empty_cage(0) directly.
+    if !fdtables::check_cage_exists(0) {
+        fdtables::init_empty_cage(0);
+    }
+}
+
+fn dump_file(imfs_path: &str, actual_path: &str) -> Result<(), String> {
+    create_host_parent_dirs(actual_path)?;
+
+    let c_actual_path =
+        CString::new(actual_path).map_err(|_| "dump target contains interior NUL".to_string())?;
+    let this_cage = getcageid();
+    let host_fd = raw_threei_syscall(
+        SYS_OPEN,
+        [
+            c_actual_path.as_ptr() as u64,
+            (fs::O_CREAT | fs::O_WRONLY | fs::O_TRUNC) as u64,
+            0o777,
+            0,
+            0,
+            0,
+        ],
+        [
+            this_cage | GRATE_MEMORY_FLAG,
+            this_cage,
+            this_cage,
+            this_cage,
+            this_cage,
+            this_cage,
+        ],
+    );
+    if host_fd < 0 {
+        return Err(format!("host open failed: {}", host_fd));
+    }
+
+    // Read from IMFS with cage 0's fd table, and write each chunk back to the
+    // host through ThreeI so teardown does not depend on Rust std filesystem I/O.
+    let dump_result = imfs::with_imfs(|state| {
+        let imfs_fd = state.open(0, imfs_path, fs::O_RDONLY, 0);
+        if imfs_fd < 0 {
+            return Err(format!("imfs open failed: {}", imfs_fd));
+        }
+
+        let mut buf = [0u8; DUMP_WRITE_CHUNK_SIZE];
+        loop {
+            let nread = state.read(0, imfs_fd as u64, &mut buf);
+            if nread < 0 {
+                let _ = state.close(0, imfs_fd as u64);
+                return Err(format!("imfs read failed: {}", nread));
+            }
+            if nread == 0 {
+                break;
+            }
+
+            write_host_all(host_fd, &buf[..nread as usize])?;
+        }
+
+        let close_ret = state.close(0, imfs_fd as u64);
+        if close_ret < 0 {
+            return Err(format!("imfs close failed: {}", close_ret));
+        }
+
+        Ok(())
+    });
+
+    let close_ret = raw_threei_syscall(
+        SYS_CLOSE,
+        [host_fd as u64, 0, 0, 0, 0, 0],
+        [
+            this_cage, this_cage, this_cage, this_cage, this_cage, this_cage,
+        ],
+    );
+    if close_ret < 0 {
+        return Err(format!("host close failed: {}", close_ret));
+    }
+
+    dump_result
+}
+
+fn create_host_parent_dirs(path: &str) -> Result<(), String> {
+    // Mirror the C dump_file helper: mkdir each parent component before opening
+    // the output file. Relative dump targets stay relative; absolute targets
+    // are built from '/'.
+    let mut components: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
+    if components.len() <= 1 {
+        return Ok(());
+    }
+
+    components.pop();
+
+    let mut dir_path = if path.starts_with('/') {
+        "/".to_string()
+    } else {
+        String::new()
+    };
+
+    for component in components {
+        if !dir_path.is_empty() && !dir_path.ends_with('/') {
+            dir_path.push('/');
+        }
+        dir_path.push_str(component);
+        mkdir_host(&dir_path)?;
+    }
+
+    Ok(())
+}
+
+fn mkdir_host(path: &str) -> Result<(), String> {
+    let c_path = CString::new(path).map_err(|_| "mkdir path contains interior NUL".to_string())?;
+    let this_cage = getcageid();
+    // Ignore mkdir's return value like the C implementation. Existing parent
+    // directories are expected and should not prevent the dump from continuing.
+    let _ = raw_threei_syscall(
+        SYS_MKDIR,
+        [c_path.as_ptr() as u64, 0o755, 0, 0, 0, 0],
+        [
+            this_cage | GRATE_MEMORY_FLAG,
+            this_cage,
+            this_cage,
+            this_cage,
+            this_cage,
+            this_cage,
+        ],
+    );
+    Ok(())
+}
+
+fn write_host_all(fd: i32, mut data: &[u8]) -> Result<(), String> {
+    let this_cage = getcageid();
+    while !data.is_empty() {
+        // Host writes may legally be partial; keep advancing until the whole
+        // IMFS chunk has been persisted or an error is reported.
+        let nwritten = raw_threei_syscall(
+            SYS_WRITE,
+            [fd as u64, data.as_ptr() as u64, data.len() as u64, 0, 0, 0],
+            [
+                this_cage,
+                this_cage | GRATE_MEMORY_FLAG,
+                this_cage,
+                this_cage,
+                this_cage,
+                this_cage,
+            ],
+        );
+
+        if nwritten < 0 {
+            return Err(format!("host write failed: {}", nwritten));
+        }
+        if nwritten == 0 {
+            return Err("host write made no progress".to_string());
+        }
+
+        data = &data[nwritten as usize..];
+    }
+
+    Ok(())
+}
+
+fn raw_threei_syscall(syscall: u64, args: [u64; 6], arg_cages: [u64; 6]) -> i32 {
+    let this_cage = getcageid();
+    // Utility syscalls target the current grate cage rather than an application
+    // cage. Pointer arguments that refer to grate-owned buffers must already
+    // carry GRATE_MEMORY_FLAG in arg_cages.
+    match make_threei_call(
+        syscall as u32,
+        0,
+        this_cage,
+        this_cage,
+        args[0],
+        arg_cages[0],
+        args[1],
+        arg_cages[1],
+        args[2],
+        arg_cages[2],
+        args[3],
+        arg_cages[3],
+        args[4],
+        arg_cages[4],
+        args[5],
+        arg_cages[5],
+        0,
+    ) {
+        Ok(ret) => ret,
+        Err(GrateError::MakeSyscallError(ret)) => ret,
+        Err(_) => -1,
     }
 }


### PR DESCRIPTION
Resolves #189 

- update Rust IMFS preloading to read host files through `make_threei_call`
  instead of `std::fs::read`
- add `DUMPS` support to copy IMFS files back to the host during teardown
- add utility cage initialization for preload/dump fdtable operations
- document Rust IMFS usage, including `PRELOADS`, `DUMPS`, `--log`, and tcc examples

This avoids a previous issue where Rust `std::fs::metadata()` can report an incorrectly huge file size, causing `std::fs::read()` to fail with out-of-memory even for tiny files.

`DUMPS` follows the C IMFS format:

```text
imfs_path=host_path;other_path
If = is omitted, the same path is used for both IMFS and host.
```