### PR TITLE
Fix IMFS st_blksize causing GNU `as` to write truncated object files

### DIFF
--- a/rust-grates/imfs-grate/src/imfs/mod.rs
+++ b/rust-grates/imfs-grate/src/imfs/mod.rs
@@ -62,6 +62,10 @@ pub struct FsData {
 
 const DIRENT64_FIXED_SIZE: usize = 8 + 8 + 2 + 1;
 const IMFS_BLOCK_SIZE: i32 = 512;
+// stat.st_blksize: preferred I/O size that glibc stdio sizes its buffer to.
+// Too small truncates seek-heavy buffered writers (e.g. GNU as). Distinct from
+// IMFS_BLOCK_SIZE, the POSIX-fixed 512-byte unit for st_blocks.
+const IMFS_PREFERRED_IO_SIZE: i32 = 4096;
 const LIND_AT_FDCWD: i32 = -100;
 const LIND_AT_NO_AUTOMOUNT: i32 = 0x800;
 const LIND_AT_EMPTY_PATH: i32 = 0x1000;
@@ -529,7 +533,7 @@ impl ImfsState {
             st_gid: node.group,
             st_rdev: 0,
             st_size: node.total_size as u64,
-            st_blksize: IMFS_BLOCK_SIZE,
+            st_blksize: IMFS_PREFERRED_IO_SIZE,
             st_blocks: (node.total_size / IMFS_BLOCK_SIZE as usize) as u32,
             st_atim: node.atime.as_stat_pair(),
             st_mtim: node.mtime.as_stat_pair(),


### PR DESCRIPTION
## Problem
  
Running GNU `as` under the rust IMFS grate silently produces a **truncated** output file. `as` exits 0 and every `write` reports success, but the object is short and unusable: a 429-byte `.s` assembles to a **1096-byte** object under IMFS vs **1480 bytes** on the real FS. `ld` then rejects it with "file format not recognized".

## Root cause
 IMFS `fill_stat` reported `st_blksize = IMFS_BLOCK_SIZE = 512`.
  
`as`/BFD writes its object through glibc stdio, which sizes its output buffer
from the file's `st_blksize`. With a 512-byte buffer, stdio flushes in 512-byte chunks and, on the final partial buffer, **leaves the trailing bytes unflushed** (the last 384 bytes of an 896-byte write), truncating the file to exactly 1096.
  
`st_blksize` (preferred I/O size, typically 4096) is distinct from `st_blocks`, which POSIX defines in fixed 512-byte units. The code had collapsed both onto the single `512` constant. 