### PR TITLE
Fix imfs constant

### DIFF
--- a/rust-grates/imfs-grate/src/handlers.rs
+++ b/rust-grates/imfs-grate/src/handlers.rs
@@ -14,6 +14,7 @@ use crate::imfs;
 const MAX_PATH_LEN: usize = 256;
 const IOV_MAX: usize = 1024;
 const LIND_AT_EMPTY_PATH: i32 = 0x1000;
+const LIND_AT_SYMLINK_NOFOLLOW: i32 = 0x100;
 
 /// Copy a null-terminated path string from a cage's address space into a local buffer.
 fn copy_path_from_cage(path_ptr: u64, path_cage: u64) -> Option<String> {
@@ -591,7 +592,7 @@ pub extern "C" fn fchmodat_handler(
     _arg6: u64,
     _arg6cage: u64,
 ) -> i32 {
-    let supported_flags = libc::AT_SYMLINK_NOFOLLOW | LIND_AT_EMPTY_PATH;
+    let supported_flags = LIND_AT_SYMLINK_NOFOLLOW | LIND_AT_EMPTY_PATH;
     if (arg4 as i32) & !supported_flags != 0 {
         return -22;
     }
@@ -665,7 +666,7 @@ pub extern "C" fn fchownat_handler(
     _arg6: u64,
     _arg6cage: u64,
 ) -> i32 {
-    let supported_flags = libc::AT_SYMLINK_NOFOLLOW | LIND_AT_EMPTY_PATH;
+    let supported_flags = LIND_AT_SYMLINK_NOFOLLOW | LIND_AT_EMPTY_PATH;
     if (arg5 as i32) & !supported_flags != 0 {
         return -22;
     }

--- a/rust-grates/imfs-grate/src/imfs/mod.rs
+++ b/rust-grates/imfs-grate/src/imfs/mod.rs
@@ -67,6 +67,8 @@ const IMFS_BLOCK_SIZE: i32 = 512;
 // IMFS_BLOCK_SIZE, the POSIX-fixed 512-byte unit for st_blocks.
 const IMFS_PREFERRED_IO_SIZE: i32 = 4096;
 const LIND_AT_FDCWD: i32 = -100;
+const LIND_AT_REMOVEDIR: i32 = 0x200;
+const LIND_AT_SYMLINK_FOLLOW: i32 = 0x400;
 const LIND_AT_NO_AUTOMOUNT: i32 = 0x800;
 const LIND_AT_EMPTY_PATH: i32 = 0x1000;
 const IMFS_STATFS_MAGIC: u64 = 0x494d_4653; // "IMFS"
@@ -1201,7 +1203,7 @@ impl ImfsState {
             Ok(path) => path,
             Err(e) => return e,
         };
-        self.stat_resolved_path(&norm_path, statbuf, flags & libc::AT_SYMLINK_NOFOLLOW == 0)
+        self.stat_resolved_path(&norm_path, statbuf, flags & AT_SYMLINK_NOFOLLOW == 0)
     }
 
     fn stat_resolved_path(
@@ -1574,7 +1576,7 @@ impl ImfsState {
     }
 
     pub fn unlinkat(&mut self, cage_id: u64, dirfd: i32, path: &str, flags: i32) -> i32 {
-        let supported_flags = libc::AT_REMOVEDIR;
+        let supported_flags = LIND_AT_REMOVEDIR;
         if flags & !supported_flags != 0 {
             return -22; // EINVAL
         }
@@ -1584,7 +1586,7 @@ impl ImfsState {
             Err(e) => return e,
         };
 
-        if flags & libc::AT_REMOVEDIR != 0 {
+        if flags & LIND_AT_REMOVEDIR != 0 {
             self.rmdir_resolved_path(&norm_path)
         } else {
             self.unlink_resolved_path(&norm_path)
@@ -1638,7 +1640,7 @@ impl ImfsState {
         newpath: &str,
         flags: i32,
     ) -> i32 {
-        let supported_flags = libc::AT_SYMLINK_FOLLOW;
+        let supported_flags = LIND_AT_SYMLINK_FOLLOW;
         if flags & !supported_flags != 0 {
             return -22; // EINVAL
         }
@@ -1654,7 +1656,7 @@ impl ImfsState {
         self.link_resolved_paths(
             &norm_oldpath,
             &norm_newpath,
-            flags & libc::AT_SYMLINK_FOLLOW != 0,
+            flags & LIND_AT_SYMLINK_FOLLOW != 0,
         )
     }
 


### PR DESCRIPTION
Resolves #204 

Grates are compiled to wasm32-wasip1 target but glibc has different constant definitions.